### PR TITLE
Fix: define frame metadata for compatibility with v12 SQL expressions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sift-grafana-datasource",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sift-grafana-datasource",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sift-grafana-datasource",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -855,6 +855,12 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 		frame.Fields...,
 	)
 
+	// Add frame metadata
+	frame.Meta = &data.FrameMeta{
+		Type:        data.FrameTypeTimeSeriesWide,
+		TypeVersion: data.FrameTypeVersion{0, 1},
+	}
+
 	return frame, nil
 }
 


### PR DESCRIPTION
# Pull Request

## Description
Defines a Dataframe type which is required for Grafana v12 SQL Expressions (private preview). This is an optional Dataframe field that is now required for SQL functionality.

## Type of change

Please check the boxes that apply to this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Ran local docker compose stack with Grafana v12 and `sqlExpressions` feature toggle enabled. Verified SQL Expression was able to load tabular data from Sift datasource.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

