### PR TITLE
fix: Ensure required defaults are present on non-migrated queries

### DIFF
--- a/src/components/VisualSiftQueryEditor.tsx
+++ b/src/components/VisualSiftQueryEditor.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useCallback, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
-import { RadioButtonGroup, InlineFieldRow, InlineField, Checkbox, InlineLabel, IconButton } from '@grafana/ui';
-import { Section } from './common/Section';
 import { QueryEditorProps } from '@grafana/data';
+import { Checkbox, IconButton, InlineField, InlineFieldRow, InlineLabel, RadioButtonGroup } from '@grafana/ui';
 import { SiftDataSource } from '../datasource';
-import { ChannelDataQuery, SiftDataSourceOptions, SiftQuery, QueryTypes, QueryType } from '../types';
+import { ChannelDataQuery, QueryType, QueryTypes, SiftDataSourceOptions, SiftQuery } from '../types';
+import { ensureQueryDefaults } from '../utils';
+import { Section } from './common/Section';
 import { QueryEditor } from './query-editor/QueryEditor';
 
 type Props = QueryEditorProps<SiftDataSource, SiftQuery, SiftDataSourceOptions>;
@@ -62,7 +63,11 @@ export const VisualSiftQueryEditor = (props: Props) => {
   const onUpdateChannelDataQueries = useCallback(
     (channelDataQueries: ChannelDataQuery[]) => {
       const latestQuery = queryRef.current;
-      onUpdateQuery({ ...latestQuery, channelDataQueries });
+      const updatedQuery = ensureQueryDefaults({
+        ...latestQuery,
+        channelDataQueries,
+      });
+      onUpdateQuery(updatedQuery as SiftQuery);
     },
     [onUpdateQuery]
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,9 @@
 import {
   AssetQuery,
+  CalculatedChannelDataQuery,
   ChannelDataQuery,
   ChannelQuery,
-  RunQuery,
-  CalculatedChannelDataQuery,
-  ChannelReferenceQuery,
+  RunQuery
 } from './types';
 
 export const DEFAULT_ASSET_QUERY: AssetQuery = { asSelect: true };

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,11 +1,11 @@
-import { DataSourceInstanceSettings, CoreApp, ScopedVars, DataQueryResponse, DataQueryRequest } from '@grafana/data';
-import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
-import { SiftQuery, SiftDataSourceOptions, DEFAULT_QUERY, AssetQuery, AssetGrafanaVariable } from './types';
-import { SiftVariableSupport } from 'variables';
-import { filterQueryBeforeRequest, replaceTemplateVariablesInQuery } from './utils';
+import { CoreApp, DataQueryRequest, DataQueryResponse, DataSourceInstanceSettings, ScopedVars } from '@grafana/data';
+import { DataSourceWithBackend } from '@grafana/runtime';
 import { Observable, from } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
+import { SiftVariableSupport } from 'variables';
 import { SiftDataSourceCache } from './datasourceCache';
+import { DEFAULT_QUERY, SiftDataSourceOptions, SiftQuery } from './types';
+import { ensureQueryDefaults, filterQueryBeforeRequest, replaceTemplateVariablesInQuery } from './utils';
 
 export class SiftDataSource extends DataSourceWithBackend<SiftQuery, SiftDataSourceOptions> {
   cache: SiftDataSourceCache;
@@ -41,11 +41,15 @@ export class SiftDataSource extends DataSourceWithBackend<SiftQuery, SiftDataSou
   }
 
   async migrateQuery(query: Partial<SiftQuery>): Promise<SiftQuery> {
+    // Ensure required fields are present
+    const queryWithDefaults = ensureQueryDefaults(query);
+
     if ('queries' in query || 'calculatedChannelQuery' in query) {
-      const result = await this.postResource<SiftQuery>('migrate-query', query);
+      const result = await this.postResource<SiftQuery>('migrate-query', queryWithDefaults);
       return { ...result, refId: query.refId || '' };
     }
-    return query as SiftQuery;
+
+    return queryWithDefaults as SiftQuery;
   }
 
   applyTemplateVariables(query: SiftQuery, scopedVars: ScopedVars): SiftQuery {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,30 +1,28 @@
-import {
-  AssetQuery,
-  ChannelQuery,
-  RunQuery,
-  Asset,
-  Run,
-  Channel,
-  ChannelDataQuery,
-  QueryTypes,
-  QueryType,
-  CalculatedChannelDataQuery,
-  SiftQuery,
-  AssetGrafanaVariable,
-} from './types';
-import { SelectableInputType, SelectableInputTypes } from './components/input/InputTypeSelect';
-import { DateTime, Duration } from 'luxon';
 import { ScopedVars, SelectableValue } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
+import { DateTime, Duration } from 'luxon';
+import { SelectableInputType, SelectableInputTypes } from './components/input/InputTypeSelect';
 import {
   DEFAULT_ASSET_QUERY,
   DEFAULT_CALCULATED_CHANNEL_DATA_QUERY,
-  DEFAULT_CALCULATED_CHANNEL_QUERY,
   DEFAULT_CHANNEL_DATA_QUERY,
   DEFAULT_CHANNEL_QUERY,
-  DEFAULT_QUERY,
-  DEFAULT_RUN_QUERY,
+  DEFAULT_RUN_QUERY
 } from './constants';
-import { getTemplateSrv } from '@grafana/runtime';
+import {
+  Asset,
+  AssetGrafanaVariable,
+  AssetQuery,
+  Channel,
+  ChannelDataQuery,
+  ChannelQuery,
+  DEFAULT_QUERY,
+  QueryType,
+  QueryTypes,
+  Run,
+  RunQuery,
+  SiftQuery
+} from './types';
 
 export const getValueAndSelectionTypeFromQuery = (
   query: ChannelQuery | RunQuery | AssetQuery | null | undefined
@@ -459,4 +457,14 @@ export class CELUtil {
 
 export const regexEscape = (regex: string, forCel = false, excludeGrafanaVarChars = false): string => {
   return regex.replace(excludeGrafanaVarChars ? /[.*+?^()|[\]\\]/g : /[.*+?^${}()|[\]\\]/g, forCel ? '\\\\$&' : '\\$&');
+};
+
+/**
+ * Ensures that a SiftQuery has all required fields with proper defaults
+ */
+export const ensureQueryDefaults = (query: Partial<SiftQuery>): Partial<SiftQuery> => {
+  return {
+    ...DEFAULT_QUERY,
+    ...query,
+  };
 };


### PR DESCRIPTION
# Pull Request

## Description

Ensure query defaults are present on queries that don't need migration.

Fixes # (issue)

## Type of change

Please check the boxes that apply to this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

Manually created malformed queries in a dashboard and reproduced the issue without the changes. Then applied these changes and confirmed the queries are fixed. Locally  added some logs to datasource.ts:migrateQuery to confirm behavior.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please add screenshots to help explain your changes if applicable.
