### PR TITLE
fix: Queries should update when query variable asset selection changes

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/google/uuid"
 	"net/http"
 	"net/url"
 	"slices"
@@ -15,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
@@ -894,13 +894,8 @@ func getChannelQueries(pCtx backend.PluginContext, cdq channelDataQuery, runIds 
 	channelIdQueries := []string{}
 	channelIdFromSelectQueries := []string{} // asSelect also redupes channels with the same name
 	for _, channelQuery := range cdq.ChannelQueries {
-		if channelQuery.ChannelId != "" {
-			if channelQuery.AsSelect {
-				channelIdFromSelectQueries = append(channelIdFromSelectQueries, channelQuery.ChannelId)
-			} else {
-				channelIdQueries = append(channelIdQueries, channelQuery.ChannelId)
-			}
-		} else if channelQuery.ChannelName != "" {
+		channelInCache, _ := d.isChannelInCache(channelQuery.ChannelId, assetIds)
+		if channelQuery.ChannelName != "" || !channelInCache {
 			// If we have a channel name, search for matching channels for each asset
 			channelSearches := make([]channelSearchKey, 0)
 			for _, assetId := range assetIds {
@@ -922,10 +917,18 @@ func getChannelQueries(pCtx backend.PluginContext, cdq channelDataQuery, runIds 
 					}
 				}
 			}
+		} else if channelQuery.ChannelId != "" {
+			if channelQuery.AsSelect {
+				channelIdFromSelectQueries = append(channelIdFromSelectQueries, channelQuery.ChannelId)
+			} else {
+				channelIdQueries = append(channelIdQueries, channelQuery.ChannelId)
+			}
 		}
+
 	}
 	// Find all channels with same name from select
-	channelsFromSelect, err := d.getChannelsAndSameNameChannelsById(pCtx, channelIdFromSelectQueries)
+	channelsFromSelect, err := d.getChannelsAndSameNameChannelsById(pCtx, channelIdFromSelectQueries, assetIds)
+
 	if err != nil {
 		return nil, fmt.Errorf("error looking up channels: %w", err)
 	}
@@ -933,7 +936,8 @@ func getChannelQueries(pCtx backend.PluginContext, cdq channelDataQuery, runIds 
 		channelIds = append(channelIds, channel.ChannelId)
 	}
 
-	results, err := d.getChannelsById(pCtx, channelIdQueries)
+	results, err := d.getChannelsById(pCtx, channelIdQueries, assetIds)
+
 	if err != nil {
 		return nil, fmt.Errorf("error looking up channels: %w", err)
 	}
@@ -999,9 +1003,9 @@ func getCalculationQueries(pCtx backend.PluginContext, cdq channelDataQuery, run
 					var results []Channel
 					var err error
 					if channelRef.AsSelect {
-						results, err = d.getChannelsAndSameNameChannelsById(pCtx, []string{channelRef.ChannelId})
+						results, err = d.getChannelsAndSameNameChannelsById(pCtx, []string{channelRef.ChannelId}, assetIds)
 					} else {
-						results, err = d.getChannelsById(pCtx, []string{channelRef.ChannelId})
+						results, err = d.getChannelsById(pCtx, []string{channelRef.ChannelId}, assetIds)
 					}
 					if err != nil {
 						return nil, nil, fmt.Errorf("error looking up channels: %w", err)

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/useragent"
 	"math"
 	"math/rand"
 	"net/http"
@@ -15,6 +14,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/useragent"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )

--- a/pkg/plugin/sift_api_queries.go
+++ b/pkg/plugin/sift_api_queries.go
@@ -484,16 +484,33 @@ func (d *SiftDatasource) getRunIdsByName(pCtx backend.PluginContext, assetIds []
 	return runIds, nil
 }
 
-func (d *SiftDatasource) getChannelsById(pCtx backend.PluginContext, channelIds []string) ([]Channel, error) {
+// isChannelInCache checks if a channel ID associated with the correct asset ID is in the cache
+func (d *SiftDatasource) isChannelInCache(channelId string, assetId []string) (bool, *Channel) {
+	cachedChannel, found := d.channelsIdSearchCache.Get(channelId)
+	if !found {
+		return false, nil
+	}
+
+	// Check if the cached channel belongs to the expected asset
+	for _, id := range assetId {
+		if cachedChannel.AssetId == id {
+			return true, &cachedChannel
+		}
+	}
+	// Channel exists in cache but belongs to a different asset
+	return false, nil
+}
+
+func (d *SiftDatasource) getChannelsById(pCtx backend.PluginContext, channelIds []string, assetIds []string) ([]Channel, error) {
 	startTime := time.Now()
 
 	cachedChannels := []Channel{}
 	channelIdsToSearch := []string{}
 
 	for _, channelId := range channelIds {
-		cachedChannel, found := d.channelsIdSearchCache.Get(channelId)
-		if found {
-			cachedChannels = append(cachedChannels, cachedChannel)
+		channelInCache, foundChannel := d.isChannelInCache(channelId, assetIds)
+		if channelInCache {
+			cachedChannels = append(cachedChannels, *foundChannel)
 		} else {
 			channelIdsToSearch = append(channelIdsToSearch, channelId)
 		}
@@ -600,10 +617,10 @@ func (d *SiftDatasource) getChannelsByName(pCtx backend.PluginContext, assetId s
 // getChannelsAndSameNameChannelsById first finds channels by ID and then searches for channels with the same name
 // This is intended to handle the case in the frontend selection where there are multiple channels with the same name.
 // The frontend dedupes on name to make selection more clear, so this undoes that
-func (d *SiftDatasource) getChannelsAndSameNameChannelsById(pCtx backend.PluginContext, channelIds []string) ([]Channel, error) {
+func (d *SiftDatasource) getChannelsAndSameNameChannelsById(pCtx backend.PluginContext, channelIds []string, assetIds []string) ([]Channel, error) {
 	startTime := time.Now()
 
-	channels, err := d.getChannelsById(pCtx, channelIds)
+	channels, err := d.getChannelsById(pCtx, channelIds, assetIds)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugin/sift_api_queries_test.go
+++ b/pkg/plugin/sift_api_queries_test.go
@@ -1,0 +1,133 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsChannelInCache(t *testing.T) {
+	// Create a new datasource instance for testing
+	ds := &SiftDatasource{
+		channelsIdSearchCache: NewTypedCache[string, Channel](0, 0),
+	}
+
+	// Test channel data
+	testChannel := Channel{
+		ChannelId: "test-channel-123",
+		Name:      "Test Channel",
+		AssetId:   "test-asset-456",
+		AssetName: "Test Asset",
+		DataType:  "CHANNEL_DATA_TYPE_DOUBLE",
+	}
+
+	t.Run("channel not in cache", func(t *testing.T) {
+		found, channel := ds.isChannelInCache("non-existent-channel", []string{"test-asset-456"})
+		assert.False(t, found)
+		assert.Nil(t, channel)
+	})
+
+	t.Run("channel in cache with matching asset ID", func(t *testing.T) {
+		// Add channel to cache
+		ds.channelsIdSearchCache.Set(testChannel.ChannelId, testChannel)
+
+		found, channel := ds.isChannelInCache("test-channel-123", []string{"test-asset-456"})
+		assert.True(t, found)
+		assert.NotNil(t, channel)
+		assert.Equal(t, testChannel.ChannelId, channel.ChannelId)
+		assert.Equal(t, testChannel.AssetId, channel.AssetId)
+	})
+
+	t.Run("channel in cache but wrong asset ID", func(t *testing.T) {
+		// Add channel to cache
+		ds.channelsIdSearchCache.Set(testChannel.ChannelId, testChannel)
+
+		found, channel := ds.isChannelInCache("test-channel-123", []string{"wrong-asset-789"})
+		assert.False(t, found)
+		assert.Nil(t, channel)
+	})
+
+	t.Run("channel in cache but asset ID not in list", func(t *testing.T) {
+		// Add channel to cache
+		ds.channelsIdSearchCache.Set(testChannel.ChannelId, testChannel)
+
+		found, channel := ds.isChannelInCache("test-channel-123", []string{"asset-1", "asset-2", "asset-3"})
+		assert.False(t, found)
+		assert.Nil(t, channel)
+	})
+
+	t.Run("channel in cache with empty asset ID list", func(t *testing.T) {
+		// Add channel to cache
+		ds.channelsIdSearchCache.Set(testChannel.ChannelId, testChannel)
+
+		found, channel := ds.isChannelInCache("test-channel-123", []string{})
+		assert.False(t, found)
+		assert.Nil(t, channel)
+	})
+
+	t.Run("multiple channels in cache", func(t *testing.T) {
+		// Clear cache and add multiple channels
+		ds.channelsIdSearchCache.Flush()
+
+		channel1 := Channel{
+			ChannelId: "channel-1",
+			Name:      "Channel 1",
+			AssetId:   "asset-1",
+			DataType:  "CHANNEL_DATA_TYPE_DOUBLE",
+		}
+
+		channel2 := Channel{
+			ChannelId: "channel-2",
+			Name:      "Channel 2",
+			AssetId:   "asset-2",
+			DataType:  "CHANNEL_DATA_TYPE_STRING",
+		}
+
+		ds.channelsIdSearchCache.Set(channel1.ChannelId, channel1)
+		ds.channelsIdSearchCache.Set(channel2.ChannelId, channel2)
+
+		// Test channel1 with correct asset
+		found, channel := ds.isChannelInCache("channel-1", []string{"asset-1"})
+		assert.True(t, found)
+		assert.Equal(t, channel1.ChannelId, channel.ChannelId)
+
+		// Test channel2 with correct asset
+		found, channel = ds.isChannelInCache("channel-2", []string{"asset-2"})
+		assert.True(t, found)
+		assert.Equal(t, channel2.ChannelId, channel.ChannelId)
+
+		// Test channel1 with wrong asset
+		found, channel = ds.isChannelInCache("channel-1", []string{"asset-2"})
+		assert.False(t, found)
+		assert.Nil(t, channel)
+	})
+
+	t.Run("channel with different asset IDs", func(t *testing.T) {
+		// Clear cache and add a channel
+		ds.channelsIdSearchCache.Flush()
+
+		channel := Channel{
+			ChannelId: "multi-asset-channel",
+			Name:      "Multi Asset Channel",
+			AssetId:   "asset-abc",
+			DataType:  "CHANNEL_DATA_TYPE_INT_64",
+		}
+
+		ds.channelsIdSearchCache.Set(channel.ChannelId, channel)
+
+		// Test with matching asset ID
+		found, foundChannel := ds.isChannelInCache("multi-asset-channel", []string{"asset-abc"})
+		assert.True(t, found)
+		assert.Equal(t, channel.ChannelId, foundChannel.ChannelId)
+
+		// Test with non-matching asset ID
+		found, foundChannel = ds.isChannelInCache("multi-asset-channel", []string{"asset-def"})
+		assert.False(t, found)
+		assert.Nil(t, foundChannel)
+
+		// Test with multiple asset IDs including the correct one
+		found, foundChannel = ds.isChannelInCache("multi-asset-channel", []string{"asset-xyz", "asset-abc", "asset-123"})
+		assert.True(t, found)
+		assert.Equal(t, channel.ChannelId, foundChannel.ChannelId)
+	})
+}

--- a/src/components/query-editor/ChannelQueryEditor.tsx
+++ b/src/components/query-editor/ChannelQueryEditor.tsx
@@ -1,15 +1,15 @@
-import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react';
-import { ChannelQuery, ChannelQueryId, QueryType, QueryTypes } from '../../types';
-import { SiftDataSource } from '../../datasource';
-import { Section } from '../common/Section';
-import { InlineLabel, useStyles2 } from '@grafana/ui';
-import { SelectableTypeInput } from '../input/SelectableTypeInput';
-import { AddButton, RemoveButton } from '../common/InlineButton';
-import { getStyles } from '../common/Common.style';
-import { getValueAndSelectionTypeFromQuery, channelQueryFromSelection, channelToSelectableValue } from '../../utils';
-import { SelectableInputTypes, SelectableInputType, SelectableInputTypeValue } from '../input/InputTypeSelect';
-import { useFetchChannels } from '../../resources.hooks';
 import { SelectableValue } from '@grafana/data';
+import { InlineLabel, useStyles2 } from '@grafana/ui';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { SiftDataSource } from '../../datasource';
+import { useFetchChannels } from '../../resources.hooks';
+import { ChannelQuery, ChannelQueryId, QueryType, QueryTypes } from '../../types';
+import { channelQueryFromSelection, channelToSelectableValue, getValueAndSelectionTypeFromQuery } from '../../utils';
+import { getStyles } from '../common/Common.style';
+import { AddButton, RemoveButton } from '../common/InlineButton';
+import { Section } from '../common/Section';
+import { SelectableInputType, SelectableInputTypes } from '../input/InputTypeSelect';
+import { SelectableTypeInput } from '../input/SelectableTypeInput';
 
 interface Props {
   datasource: SiftDataSource;
@@ -91,19 +91,6 @@ export const ChannelQueryEditor = ({
       void loadChannels(selectedAssetIds, undefined, selectedChannelIds || undefined);
     }
   }, [selectedChannelType, selectedAssetIds, selectedChannelIds, loadChannels]);
-
-  // If selected AssetIds change, need to update selection
-  const selectedAssetIdsRef = useRef<string[]>(selectedAssetIds);
-  const lastSelectedAssetIdsRef = useRef<string[]>([]);
-  useEffect(() => {
-    if (selectedAssetIdsRef.current !== selectedAssetIds) {
-      lastSelectedAssetIdsRef.current = selectedAssetIdsRef.current;
-      selectedAssetIdsRef.current = selectedAssetIds;
-      if (selectedChannelType === SelectableInputTypes.SELECT) {
-        setSelectedChannelValue('');
-      }
-    }
-  }, [selectedAssetIds, selectedChannelType]);
 
   const channelSelectableTypes = useMemo(
     () => [

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -216,7 +216,6 @@ export const filterQueryBeforeRequest = (query: SiftQuery): SiftQuery => {
 };
 
 export const replaceTemplateVariablesInQuery = (query: SiftQuery, scopedVars: ScopedVars): SiftQuery => {
-  console.log('[SIFT-QUERY] replaceTemplateVariablesInQuery', query, scopedVars);
   const templateSrv = getTemplateSrv();
 
   function getValuesForVariable(name: string, scopedVars: ScopedVars): string[] {
@@ -247,7 +246,6 @@ export const replaceTemplateVariablesInQuery = (query: SiftQuery, scopedVars: Sc
                   dashboardVariableName: aq.dashboardVariableName,
                 });
               });
-              console.log('[SIFT-QUERY] dashboardVarValues', dashboardVarValues);
             }
           } else {
             acc.push({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -216,6 +216,7 @@ export const filterQueryBeforeRequest = (query: SiftQuery): SiftQuery => {
 };
 
 export const replaceTemplateVariablesInQuery = (query: SiftQuery, scopedVars: ScopedVars): SiftQuery => {
+  console.log('[SIFT-QUERY] replaceTemplateVariablesInQuery', query, scopedVars);
   const templateSrv = getTemplateSrv();
 
   function getValuesForVariable(name: string, scopedVars: ScopedVars): string[] {
@@ -246,6 +247,7 @@ export const replaceTemplateVariablesInQuery = (query: SiftQuery, scopedVars: Sc
                   dashboardVariableName: aq.dashboardVariableName,
                 });
               });
+              console.log('[SIFT-QUERY] dashboardVarValues', dashboardVarValues);
             }
           } else {
             acc.push({


### PR DESCRIPTION
# Pull Request

## Description

The channel caching logic was not checking the asset ID. So when the asset ID selected by a query variable changed, but channel queries were already cached, the caching logic saw there were already channel IDs selected and didn't know to update the selected channel IDs. 
This PR makes it so that the channel cache checks whether the channel ID belongs to the asset ID in the query, and the channel cache will update the cached channel IDs if a new asset ID is seen.

The frontend also would clear the channel selection when in select mode when an asset ID would change. This made it so that when users are using the channel select dropdown menu, and update their query variable selection, the channel selections appeared to be cleared on the frontend, even though the backend queries work correctly. This PR removes the logic that clears the channel selection text in the text box, so now this behavior is consistent with all the other channel selection modes and does not clear the selection. The selection dropdown menu still updates and allows users to select new channels when needed.

Fixes # (issue)

## Type of change

Please check the boxes that apply to this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manually tested against development.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

