### PR TITLE
Fix: frontend cache request cancelling

### DIFF
--- a/src/datasourceCache.ts
+++ b/src/datasourceCache.ts
@@ -138,9 +138,11 @@ export class SiftDataSourceCache {
       }
 
       let newFrames: DataFrame[][] = [];
-      // Fire off sub‑queries for each missing range
-      await Promise.all(
-        fetchRanges.map(async (rng) => {
+      // Sequential processing using reduce since parallel requests will cancel each other
+      await fetchRanges.reduce(async (previousPromise, rng) => {
+        await previousPromise; // Wait for the previous request to complete
+
+        try {
           const subReq: DataQueryRequest<SiftQuery> = {
             ...request,
             range: {
@@ -157,27 +159,45 @@ export class SiftDataSourceCache {
             console.error(
               `Panel ${panelId} - Failed to fetch data from ${new Date(rng.from).toISOString()} to ${new Date(
                 rng.to
-              ).toISOString()}`
+              ).toISOString()}`,
+              subResp
             );
           }
-        })
-      );
+        } catch (error) {
+          console.error(
+            `Panel ${panelId} - Error fetching range ${new Date(rng.from).toISOString()} to ${new Date(
+              rng.to
+            ).toISOString()}:`,
+            error
+          );
+        }
+      }, Promise.resolve());
 
-      let updatedCacheFrames: DataFrame[] = [];
+      let refIdToFrameMap = new Map<string, DataFrame>();
+
+      // Initialize the map with trimmed cache frames
+      trimmedCacheFrames.forEach((frame) => {
+        if (frame.refId) {
+          refIdToFrameMap.set(frame.refId, frame);
+        }
+      });
+
+      // Process new frames and merge with cached ones
       newFrames.forEach((frames) => {
         frames.forEach((frame) => {
-          const matchingCachedFrame = trimmedCacheFrames.find((cachedFrame) => {
-            return cachedFrame.refId === frame.refId;
-          });
-
-          // If cached frame exists, append to it
-          if (matchingCachedFrame) {
-            updatedCacheFrames.push(appendFramesByTime(matchingCachedFrame, frame));
-          } else {
-            updatedCacheFrames.push(frame);
+          if (frame.refId) {
+            const cachedFrame = refIdToFrameMap.get(frame.refId);
+            if (cachedFrame) {
+              refIdToFrameMap.set(frame.refId, appendFramesByTime(cachedFrame, frame));
+            } else {
+              refIdToFrameMap.set(frame.refId, frame);
+            }
           }
         });
       });
+
+      // Convert map back to array
+      const updatedCacheFrames = Array.from(refIdToFrameMap.values());
 
       const filteredFrames = updatedCacheFrames.map((frame) => filterFrameByTimeRange(frame, newFrom, newTo));
 


### PR DESCRIPTION
# Pull Request

## Description
Fixes issue where the delta time queries used by the frontend cache (for populating data left and/or right of the cached data) would cancel one another once one completed.

Fix for: [FD-169](https://linear.app/siftstack/issue/FD-169)


## Type of change

Please check the boxes that apply to this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Validated working by running provisioned dashboard locally and bug no longer present

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please add screenshots to help explain your changes if applicable.
