### PR TITLE
Fix: getData timeout

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
         grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-11.0.0}
     ports:
-      - 3000:3000/tcp
+      - 3005:3000/tcp
     volumes:
       - ./dist:/var/lib/grafana/plugins/sift-grafana-datasource
       - ./provisioning:/etc/grafana/provisioning

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -69,11 +69,6 @@ func NewSiftDatasource(ctx context.Context, s backend.DataSourceInstanceSettings
 		return nil, err
 	}
 
-	// timeout of 60 seconds for Sift API queries
-	opts.Timeouts = &httpclient.TimeoutOptions{
-		Timeout: 60 * time.Second,
-	}
-
 	httpClient, err := httpclient.New(opts)
 	if err != nil {
 		return nil, err

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -68,6 +68,12 @@ func NewSiftDatasource(ctx context.Context, s backend.DataSourceInstanceSettings
 	if err != nil {
 		return nil, err
 	}
+
+	// timeout of 60 seconds for Sift API queries
+	opts.Timeouts = &httpclient.TimeoutOptions{
+		Timeout: 60 * time.Second,
+	}
+
 	httpClient, err := httpclient.New(opts)
 	if err != nil {
 		return nil, err

--- a/pkg/plugin/sift_api_queries.go
+++ b/pkg/plugin/sift_api_queries.go
@@ -217,7 +217,7 @@ func (d *SiftDatasource) getData(pCtx backend.PluginContext, subQueries []siftAp
 		req := apiRequest{
 			pCtx:   pCtx,
 			method: "POST",
-			path:   "/api/v2/data",
+			path:   "/api/v2/internal/data",
 			body:   backendQuery,
 		}
 


### PR DESCRIPTION
# Pull Request

## Description

Long getData requests will no longer timeout. Switches to the internal getData endpoint which auto-paginates at 10s intervals (rather than by number of data points).

## Type of change

Please check the boxes that apply to this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please add screenshots to help explain your changes if applicable.
