### PR TITLE
Fix: annotation query defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sift-grafana-datasource",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sift-grafana-datasource",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sift-grafana-datasource",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/plugin/migrate_query.go
+++ b/pkg/plugin/migrate_query.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"net/http"
 	"strings"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
 type legacyCalculatedChannelQuery struct {
@@ -40,6 +41,8 @@ type legacyQueryModel struct {
 	RunId                  string                        `json:"runId"`
 	RunName                string                        `json:"runName"`
 	Hide                   bool                          `json:"hide"`
+	AnnotationType         string                        `json:"annotationType"`
+	AnnotationFilter       string                        `json:"annotationFilter"`
 }
 
 // convertQueryIfNeeded checks if the query is in a legacy format and converts it if needed
@@ -119,8 +122,10 @@ func convertLegacyQuery(orig json.RawMessage) (*queryModel, error) {
 	}
 
 	migratedInput := &queryModel{
-		CombineRuns:  !input.GroupByRun,
-		QueryVersion: QueryVersion,
+		CombineRuns:      !input.GroupByRun,
+		QueryVersion:     QueryVersion,
+		AnnotationType:   input.AnnotationType,
+		AnnotationFilter: input.AnnotationFilter,
 	}
 
 	// Map to store unique asset+run combinations to reduce the number of unique SELECT blocks

--- a/pkg/plugin/migrate_query_test.go
+++ b/pkg/plugin/migrate_query_test.go
@@ -422,6 +422,36 @@ func TestConvertQuery(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "annotation query without queryVersion preserves annotation fields through migration",
+			input: `{
+				"refId": "Anno",
+				"annotationType": "annotationsQuery",
+				"annotationFilter": "asset_name=='blah'"
+			}`,
+			needsMigration: true,
+			expected: &queryModel{
+				CombineRuns:      true,
+				QueryVersion:     QueryVersion,
+				AnnotationType:   "annotationsQuery",
+				AnnotationFilter: "asset_name=='blah'",
+			},
+			expectError: false,
+		},
+		{
+			name: "annotation query without queryVersion and empty filter preserves annotationType",
+			input: `{
+				"refId": "Anno",
+				"annotationType": "annotationsQuery"
+			}`,
+			needsMigration: true,
+			expected: &queryModel{
+				CombineRuns:    true,
+				QueryVersion:   QueryVersion,
+				AnnotationType: "annotationsQuery",
+			},
+			expectError: false,
+		},
+		{
 			name:           "invalid json",
 			input:          `{invalid json}`,
 			needsMigration: false,

--- a/src/components/AnnotationQueryEditor.test.tsx
+++ b/src/components/AnnotationQueryEditor.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { AnnotationQueryEditor } from './AnnotationQueryEditor';
+import { SiftDataSource } from '../datasource';
+import { QUERY_VERSION } from '../types';
+
+// Mock the VisualSiftQueryEditor component
+jest.mock('./VisualSiftQueryEditor', () => ({
+  VisualSiftQueryEditor: jest.fn(() => <div data-testid="mock-visual-query-editor" />),
+}));
+
+// Mock the useFetchSharelinkMetadata hook (used by VisualSiftQueryEditor)
+jest.mock('../resources.hooks', () => ({
+  useFetchSharelinkMetadata: jest.fn(() => ({
+    shareLinkItems: {
+      channelIds: [],
+      assetIds: [],
+      runIds: [],
+      calculatedChannels: [],
+    },
+  })),
+}));
+
+const createMockDatasource = () =>
+  ({
+    migrateQuery: jest.fn(),
+    getApiRestUrl: jest.fn(() => 'https://sift.example.com'),
+    getFrontendUrl: jest.fn(() => undefined),
+    clearCache: jest.fn(),
+    postResource: jest.fn().mockResolvedValue(undefined),
+  }) as unknown as SiftDataSource;
+
+describe('AnnotationQueryEditor', () => {
+  let mockDatasource: SiftDataSource;
+  let mockOnChange: jest.Mock;
+  let mockOnRunQuery: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDatasource = createMockDatasource();
+    mockOnChange = jest.fn();
+    mockOnRunQuery = jest.fn();
+  });
+
+  describe('onChange always includes queryVersion', () => {
+    it('includes queryVersion on initialization when query has no queryVersion', async () => {
+      const query = {
+        refId: 'Anno',
+        annotationType: undefined,
+        annotationFilter: '',
+      } as any;
+
+      render(
+        <AnnotationQueryEditor
+          query={query}
+          onChange={mockOnChange}
+          onRunQuery={mockOnRunQuery}
+          datasource={mockDatasource}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenCalled();
+      });
+
+      // Every onChange call must include queryVersion
+      for (const call of mockOnChange.mock.calls) {
+        expect(call[0]).toHaveProperty('queryVersion', QUERY_VERSION);
+      }
+    });
+
+    it('includes queryVersion on initialization when query already has queryVersion', async () => {
+      const query = {
+        refId: 'Anno',
+        queryVersion: QUERY_VERSION,
+        annotationType: undefined,
+      } as any;
+
+      render(
+        <AnnotationQueryEditor
+          query={query}
+          onChange={mockOnChange}
+          onRunQuery={mockOnRunQuery}
+          datasource={mockDatasource}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenCalled();
+      });
+
+      for (const call of mockOnChange.mock.calls) {
+        expect(call[0]).toHaveProperty('queryVersion', QUERY_VERSION);
+      }
+    });
+
+    it('includes queryVersion when switching annotation type', async () => {
+      const query = {
+        refId: 'Anno',
+        queryVersion: QUERY_VERSION,
+        annotationType: 'annotationsQuery',
+        annotationFilter: '',
+      } as any;
+
+      render(
+        <AnnotationQueryEditor
+          query={query}
+          onChange={mockOnChange}
+          onRunQuery={mockOnRunQuery}
+          datasource={mockDatasource}
+        />
+      );
+
+      // Wait for initialization
+      await waitFor(() => {
+        expect(screen.getByText('Sift Annotations')).toBeInTheDocument();
+      });
+
+      // Switch to Data Query
+      const dataQueryRadio = screen.getByLabelText('Data Query');
+      fireEvent.click(dataQueryRadio);
+
+      // Every onChange call must include queryVersion
+      for (const call of mockOnChange.mock.calls) {
+        expect(call[0]).toHaveProperty('queryVersion', QUERY_VERSION);
+      }
+    });
+
+    it('includes queryVersion when annotation filter is changed', async () => {
+      const query = {
+        refId: 'Anno',
+        queryVersion: QUERY_VERSION,
+        annotationType: 'annotationsQuery',
+        annotationFilter: '',
+      } as any;
+
+      render(
+        <AnnotationQueryEditor
+          query={query}
+          onChange={mockOnChange}
+          onRunQuery={mockOnRunQuery}
+          datasource={mockDatasource}
+        />
+      );
+
+      // Wait for initialization
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText("example: asset_name == 'rover_1'")).toBeInTheDocument();
+      });
+
+      // Type in the filter input and blur to trigger onChange
+      const filterInput = screen.getByPlaceholderText("example: asset_name == 'rover_1'");
+      fireEvent.change(filterInput, { target: { value: "asset_name=='test'" } });
+      fireEvent.blur(filterInput);
+
+      // Every onChange call must include queryVersion
+      for (const call of mockOnChange.mock.calls) {
+        expect(call[0]).toHaveProperty('queryVersion', QUERY_VERSION);
+      }
+    });
+  });
+});

--- a/src/components/AnnotationQueryEditor.tsx
+++ b/src/components/AnnotationQueryEditor.tsx
@@ -4,6 +4,7 @@ import { GrafanaTheme2, QueryEditorProps } from '@grafana/data';
 import { Icon, InlineField, InlineFieldRow, Input, RadioButtonGroup, Text, TextLink, useStyles2 } from '@grafana/ui';
 import { SiftDataSource } from '../datasource';
 import { AnnotationQueryType, SiftQuery, SiftDataSourceOptions } from '../types';
+import { ensureQueryDefaults } from '../utils';
 import { VisualSiftQueryEditor } from './VisualSiftQueryEditor';
 
 type Props = QueryEditorProps<SiftDataSource, SiftQuery, SiftDataSourceOptions>;
@@ -129,12 +130,12 @@ export const AnnotationQueryEditor = (props: Props) => {
     setAnnotationType(initAnnotationType);
     setAnnotationFilter(query.annotationFilter || '');
 
-    // Ensure query has annotationType set
-    if (!query.annotationType) {
-      onChange({
+    // Ensure query has annotationType and required defaults (e.g. queryVersion) set
+    if (!query.annotationType || !query.queryVersion) {
+      onChange(ensureQueryDefaults({
         ...query,
         annotationType: initAnnotationType,
-      });
+      }) as SiftQuery);
     }
 
     setInitialized(true);
@@ -143,10 +144,10 @@ export const AnnotationQueryEditor = (props: Props) => {
   const onAnnotationTypeChange = useCallback(
     (newAnnotationType: AnnotationQueryType) => {
       setAnnotationType(newAnnotationType);
-      onChange({
+      onChange(ensureQueryDefaults({
         ...query,
         annotationType: newAnnotationType,
-      });
+      }) as SiftQuery);
       onRunQuery();
     },
     [query, onChange, onRunQuery]
@@ -155,10 +156,10 @@ export const AnnotationQueryEditor = (props: Props) => {
   // Wrap onChange to always include annotationType
   const onChangeWithAnnotationType = useCallback(
     (updatedQuery: SiftQuery) => {
-      onChange({
+      onChange(ensureQueryDefaults({
         ...updatedQuery,
         annotationType,
-      });
+      }) as SiftQuery);
     },
     [onChange, annotationType]
   );
@@ -168,11 +169,11 @@ export const AnnotationQueryEditor = (props: Props) => {
   }, []);
 
   const onAnnotationFilterBlur = useCallback(() => {
-    onChange({
+    onChange(ensureQueryDefaults({
       ...query,
       annotationType,
       annotationFilter,
-    });
+    }) as SiftQuery);
     onRunQuery();
   }, [query, onChange, onRunQuery, annotationType, annotationFilter]);
 

--- a/src/components/VisualSiftQueryEditor.test.tsx
+++ b/src/components/VisualSiftQueryEditor.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { VisualSiftQueryEditor } from './VisualSiftQueryEditor';
 import { SiftDataSource } from '../datasource';
 import { QueryEditor } from './query-editor/QueryEditor';
-import { QueryTypes } from '../types';
+import { QueryTypes, QUERY_VERSION } from '../types';
 import { OpenInSiftButton } from './sharelink/OpenInSiftButton';
 
 // Mock the QueryEditor component
@@ -543,6 +543,71 @@ describe('VisualSiftQueryEditor', () => {
         }),
         expect.anything()
       );
+    });
+  });
+
+  describe('onChange always includes queryVersion', () => {
+    it('includes queryVersion when channel data queries are updated', async () => {
+      const query = {
+        refId: 'A',
+        queryVersion: QUERY_VERSION,
+        channelDataQueries: [],
+      };
+
+      mockDatasource.migrateQuery.mockResolvedValue(query);
+
+      render(
+        <VisualSiftQueryEditor
+          query={query as any}
+          onChange={mockOnChange}
+          onRunQuery={mockOnRunQuery}
+          datasource={mockDatasource as unknown as SiftDataSource}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('mock-query-editor')).toBeInTheDocument();
+      });
+
+      const { onUpdateChannelDataQueries } = (QueryEditor as jest.Mock).mock.calls[0][0];
+      const newChannelDataQueries = [
+        { assetQueries: [{ assetId: 'new-asset' }], channelQueries: [{ channelId: 'new-channel' }] },
+      ];
+      await waitFor(() => onUpdateChannelDataQueries(newChannelDataQueries));
+
+      for (const call of mockOnChange.mock.calls) {
+        expect(call[0]).toHaveProperty('queryVersion', QUERY_VERSION);
+      }
+    });
+
+    it('includes queryVersion when combineRuns is toggled', async () => {
+      const query = {
+        refId: 'A',
+        queryVersion: QUERY_VERSION,
+        channelDataQueries: [],
+        combineRuns: false,
+      };
+
+      mockDatasource.migrateQuery.mockResolvedValue(query);
+
+      render(
+        <VisualSiftQueryEditor
+          query={query as any}
+          onChange={mockOnChange}
+          onRunQuery={mockOnRunQuery}
+          datasource={mockDatasource as unknown as SiftDataSource}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('GROUP BY')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByLabelText('Combine Runs'));
+
+      for (const call of mockOnChange.mock.calls) {
+        expect(call[0]).toHaveProperty('queryVersion', QUERY_VERSION);
+      }
     });
   });
 

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,6 +1,6 @@
 import { SiftDataSource } from './datasource';
 import { getTemplateSrv } from '@grafana/runtime';
-import { SiftQuery, QueryTypes } from './types';
+import { SiftQuery, QueryTypes, QUERY_VERSION } from './types';
 
 // Mock the getTemplateSrv function
 jest.mock('@grafana/runtime', () => ({
@@ -44,6 +44,67 @@ describe('SiftDataSource', () => {
     (getTemplateSrv as jest.Mock).mockReturnValue(mockTemplateSrv);
 
     datasource = new SiftDataSource({} as any);
+  });
+
+  describe('migrateQuery', () => {
+    it('skips migration when queryVersion is current', async () => {
+      const query: Partial<SiftQuery> = {
+        refId: 'Anno',
+        queryVersion: QUERY_VERSION,
+        annotationType: 'annotationsQuery',
+        annotationFilter: "asset_name=='blah'",
+      };
+
+      const result = await datasource.migrateQuery(query);
+
+      expect(datasource.postResource).not.toHaveBeenCalled();
+      expect(result.annotationType).toBe('annotationsQuery');
+      expect(result.annotationFilter).toBe("asset_name=='blah'");
+      expect(result.queryVersion).toBe(QUERY_VERSION);
+    });
+
+    it('triggers backend migration when queryVersion is missing', async () => {
+      const query: Partial<SiftQuery> = {
+        refId: 'Anno',
+        annotationType: 'annotationsQuery',
+        annotationFilter: "asset_name=='blah'",
+      };
+
+      // Backend migration now preserves annotation fields
+      (datasource.postResource as jest.Mock).mockResolvedValue({
+        queryVersion: QUERY_VERSION,
+        combineRuns: true,
+        annotationType: 'annotationsQuery',
+        annotationFilter: "asset_name=='blah'",
+      });
+
+      const result = await datasource.migrateQuery(query);
+
+      expect(datasource.postResource).toHaveBeenCalledWith('migrate-query', query);
+      expect(result.annotationType).toBe('annotationsQuery');
+      expect(result.annotationFilter).toBe("asset_name=='blah'");
+      expect(result.queryVersion).toBe(QUERY_VERSION);
+      expect(result.refId).toBe('Anno');
+    });
+
+    it('triggers backend migration when legacy fields are present', async () => {
+      const query: Partial<SiftQuery> = {
+        refId: 'A',
+        queries: [{ assetId: 'asset123', channelId: 'chan456' }],
+      } as any;
+
+      (datasource.postResource as jest.Mock).mockResolvedValue({
+        queryVersion: QUERY_VERSION,
+        combineRuns: true,
+        channelDataQueries: [{ assetQueries: [{ assetId: 'asset123' }] }],
+      });
+
+      const result = await datasource.migrateQuery(query);
+
+      expect(datasource.postResource).toHaveBeenCalledWith('migrate-query', query);
+      expect(result.queryVersion).toBe(QUERY_VERSION);
+      expect(result.refId).toBe('A');
+    });
   });
 
   describe('applyTemplateVariables', () => {


### PR DESCRIPTION
# Pull Request

## Description

Fixes a bug where the Sift Annotations initial query was missing a version resulting in a migration and stripping of the actual query.

## Type of change

Please check the boxes that apply to this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please add screenshots to help explain your changes if applicable.
