### PR TITLE
Fix: Add Sift endpoint timeout

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -69,11 +69,11 @@ func StringFromChannelSearchKey(c channelSearchKey) string {
 	return fmt.Sprintf("[%s] %s", c.assetId, c.searchTerm)
 }
 
-// siftApiTimeout is the HTTP client timeout for requests from the plugin to the Sift API.
-// Long-running data queries (e.g. large time ranges) can take multiple minutes before Sift returns
-// the first byte; without this override the default client timeout causes "timeout awaiting
-// response headers" and failed panels.
-const siftApiTimeout = 5 * time.Minute
+// defaultSiftApiTimeout is the default HTTP client timeout for requests from the plugin to the Sift API
+// when the datasource does not set a custom value (queryTimeoutSeconds). Long-running data queries
+// can take multiple minutes before Sift returns the first byte; without an override the default client
+// timeout causes "timeout awaiting response headers" and failed panels.
+const defaultSiftApiTimeout = 5 * time.Minute
 
 // NewSiftDatasource creates a new datasource instance.
 func NewSiftDatasource(ctx context.Context, s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
@@ -87,7 +87,10 @@ func NewSiftDatasource(ctx context.Context, s backend.DataSourceInstanceSettings
 	if opts.Timeouts == nil {
 		opts.Timeouts = &httpclient.TimeoutOptions{}
 	}
-	opts.Timeouts.Timeout = siftApiTimeout
+	opts.Timeouts.Timeout = defaultSiftApiTimeout
+	if sec := getQueryTimeoutSeconds(s.JSONData); sec > 0 {
+		opts.Timeouts.Timeout = time.Duration(sec) * time.Second
+	}
 
 	httpClient, err := httpclient.New(opts)
 	if err != nil {
@@ -208,8 +211,9 @@ func (d *SiftDatasource) QueryData(ctx context.Context, req *backend.QueryDataRe
 }
 
 type jsonData struct {
-	Url         string `json:"url"`
-	FrontendUrl string `json:"frontendUrl"`
+	Url                 string `json:"url"`
+	FrontendUrl         string `json:"frontendUrl"`
+	QueryTimeoutSeconds int    `json:"queryTimeoutSeconds"`
 }
 
 type commonQueryProperties struct {
@@ -384,6 +388,17 @@ type calculatedChannelKey struct {
 type channelSearchKey struct {
 	assetId    string
 	searchTerm string
+}
+
+func getQueryTimeoutSeconds(jsonDataBytes []byte) int {
+	var jd jsonData
+	if err := json.Unmarshal(jsonDataBytes, &jd); err != nil {
+		return 0
+	}
+	if jd.QueryTimeoutSeconds <= 0 {
+		return 0
+	}
+	return jd.QueryTimeoutSeconds
 }
 
 func getApiUrl(dataSourceInstanceSettings *backend.DataSourceInstanceSettings) (*url.URL, error) {

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -69,6 +69,12 @@ func StringFromChannelSearchKey(c channelSearchKey) string {
 	return fmt.Sprintf("[%s] %s", c.assetId, c.searchTerm)
 }
 
+// siftApiTimeout is the HTTP client timeout for requests from the plugin to the Sift API.
+// Long-running data queries (e.g. large time ranges) can take multiple minutes before Sift returns
+// the first byte; without this override the default client timeout causes "timeout awaiting
+// response headers" and failed panels.
+const siftApiTimeout = 5 * time.Minute
+
 // NewSiftDatasource creates a new datasource instance.
 func NewSiftDatasource(ctx context.Context, s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 	// Initialize http client
@@ -76,6 +82,12 @@ func NewSiftDatasource(ctx context.Context, s backend.DataSourceInstanceSettings
 	if err != nil {
 		return nil, err
 	}
+	// Override timeout for outbound calls to Sift so long queries
+	// do not fail with "Client.Timeout exceeded while awaiting headers".
+	if opts.Timeouts == nil {
+		opts.Timeouts = &httpclient.TimeoutOptions{}
+	}
+	opts.Timeouts.Timeout = siftApiTimeout
 
 	httpClient, err := httpclient.New(opts)
 	if err != nil {

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -24,6 +24,18 @@ export function ConfigEditor(props: Props) {
     onOptionsChange({ ...options, jsonData });
   };
 
+  const onQueryTimeoutChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const raw = event.target.value.trim();
+    const parsed = raw === '' ? undefined : parseInt(raw, 10);
+    const queryTimeoutSeconds =
+      parsed !== undefined && !Number.isNaN(parsed) ? parsed : undefined;
+    const jsonData = {
+      ...options.jsonData,
+      queryTimeoutSeconds,
+    };
+    onOptionsChange({ ...options, jsonData });
+  };
+
   // Secure field (only sent to the backend)
   const onAPIKeyChange = (event: ChangeEvent<HTMLInputElement>) => {
     onOptionsChange({
@@ -84,6 +96,24 @@ export function ConfigEditor(props: Props) {
           value={jsonData.frontendUrl || ''}
           placeholder="Sift frontend URL (optional)"
           width={40}
+        />
+      </InlineField>
+      <InlineField
+        label="Query timeout (s)"
+        labelWidth={20}
+        tooltip="Max seconds to wait for the Sift API per request. Leaving blank will use the default (300 seconds)."
+      >
+        <Input
+          type="number"
+          min={1}
+          onChange={onQueryTimeoutChange}
+          value={
+            jsonData.queryTimeoutSeconds != null && jsonData.queryTimeoutSeconds > 0
+              ? String(jsonData.queryTimeoutSeconds)
+              : ''
+          }
+          placeholder="300"
+          width={20}
         />
       </InlineField>
     </Stack>

--- a/src/legacyTypes.ts
+++ b/src/legacyTypes.ts
@@ -49,6 +49,7 @@ export const DEFAULT_QUERY: Partial<SiftQuery> = {
 export interface SiftDataSourceOptions extends DataSourceJsonData {
   url?: string;
   frontendUrl?: string;
+  queryTimeoutSeconds?: number;
 }
 
 /**


### PR DESCRIPTION
# Pull Request

## Description

Adds a custom timeout for data queries to Sift, to account for potentially long query times when requesting data for significant ranges of time.

Default timeout is 300 secs, and is configurable by the user in the Sift datasource settings.

<img width="582" height="464" alt="image" src="https://github.com/user-attachments/assets/7842d95e-15c9-4d90-9c49-6e23b9f6c85f" />
