### PR TITLE
Fix: Act on early query cancellation

### DIFF
--- a/pkg/plugin/cache_utils.go
+++ b/pkg/plugin/cache_utils.go
@@ -3,12 +3,13 @@ package plugin
 import (
 	"context"
 	"fmt"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
-	"github.com/patrickmn/go-cache"
 	"math/rand"
 	"sync"
 	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/patrickmn/go-cache"
 )
 
 // TypedCache is a type-safe wrapper around go-cache
@@ -116,7 +117,10 @@ func (tc *TypedCacheWithLoader[K, V, C]) GetOrWait(ctx context.Context, d *SiftD
 	// Haven't started loading it
 	log.DefaultLogger.Debug("initiating new cache load", "key", comparableKey)
 	load = sync.OnceValues(func() (V, error) {
-		v, err := tc.loader(ctx, d, pCtx, key)
+		// We pass context.WithoutCancel to the loader to avoid a scenario where the first caller's request is cancelled,
+		// causing the loader to run with a cancelled context. This would store the error and return it to all concurrent
+		// waiters, even those whose own contexts are still live.
+		v, err := tc.loader(context.WithoutCancel(ctx), d, pCtx, key)
 		tc.mu.Lock()
 		defer tc.mu.Unlock()
 

--- a/pkg/plugin/cache_utils.go
+++ b/pkg/plugin/cache_utils.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"context"
 	"fmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
@@ -79,10 +80,10 @@ type TypedCacheWithLoader[K any, V any, C comparable] struct {
 	mu              *sync.Mutex
 	keyToComparable func(K) C
 	loading         map[C]func() (V, error)
-	loader          func(*SiftDatasource, backend.PluginContext, K) (V, error)
+	loader          func(context.Context, *SiftDatasource, backend.PluginContext, K) (V, error)
 }
 
-func NewTypedCacheWithLoader[K any, V any, C comparable](typedCache *TypedCache[C, V], loader func(*SiftDatasource, backend.PluginContext, K) (V, error), keyToComparable func(K) C) *TypedCacheWithLoader[K, V, C] {
+func NewTypedCacheWithLoader[K any, V any, C comparable](typedCache *TypedCache[C, V], loader func(context.Context, *SiftDatasource, backend.PluginContext, K) (V, error), keyToComparable func(K) C) *TypedCacheWithLoader[K, V, C] {
 	return &TypedCacheWithLoader[K, V, C]{
 		TypedCache:      typedCache,
 		mu:              &sync.Mutex{},
@@ -93,7 +94,7 @@ func NewTypedCacheWithLoader[K any, V any, C comparable](typedCache *TypedCache[
 }
 
 // GetOrWait retrieves an item from the cache and waits on any other goroutine that is setting the value
-func (tc *TypedCacheWithLoader[K, V, C]) GetOrWait(d *SiftDatasource, ctx backend.PluginContext, key K) (V, error) {
+func (tc *TypedCacheWithLoader[K, V, C]) GetOrWait(ctx context.Context, d *SiftDatasource, pCtx backend.PluginContext, key K) (V, error) {
 	tc.mu.Lock()
 	comparableKey := tc.keyToComparable(key)
 	value, found := tc.cache.Get(fmt.Sprintf("%v", comparableKey))
@@ -115,7 +116,7 @@ func (tc *TypedCacheWithLoader[K, V, C]) GetOrWait(d *SiftDatasource, ctx backen
 	// Haven't started loading it
 	log.DefaultLogger.Debug("initiating new cache load", "key", comparableKey)
 	load = sync.OnceValues(func() (V, error) {
-		v, err := tc.loader(d, ctx, key)
+		v, err := tc.loader(ctx, d, pCtx, key)
 		tc.mu.Lock()
 		defer tc.mu.Unlock()
 

--- a/pkg/plugin/cache_utils_test.go
+++ b/pkg/plugin/cache_utils_test.go
@@ -304,3 +304,72 @@ func TestTypedCacheWithLoader_GetOrWait_WithComplexTypes(t *testing.T) {
 		t.Errorf("Expected cached data 'complex-data-asset123', got %s", cachedValue.Data)
 	}
 }
+
+// TestTypedCacheWithLoader_GetOrWait_FirstCallerCancelled verifies that when the first caller's
+// context is cancelled, the loader still completes successfully, and other concurrent calls (with uncancelled contexts)
+// receive the loaded value instead of a context.Canceled error.
+func TestTypedCacheWithLoader_GetOrWait_FirstCallerCancelled(t *testing.T) {
+	cache := NewTypedCache[string, string](1*time.Minute, 1*time.Minute)
+
+	// Loader runs long enough that we can cancel the first caller's context mid-load.
+	loadDuration := 100 * time.Millisecond
+	loader := func(ctx context.Context, d *SiftDatasource, pCtx backend.PluginContext, key string) (string, error) {
+		select {
+		case <-time.After(loadDuration):
+			return "loaded-value", nil
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+
+	cacheWithLoader := NewTypedCacheWithLoader(cache, loader, func(k string) string { return k })
+	mockDatasource := &SiftDatasource{}
+	mockContext := backend.PluginContext{}
+
+	ctxFirst, cancelFirst := context.WithCancel(context.Background())
+	defer cancelFirst()
+
+	var wg sync.WaitGroup
+	results := make([]string, 3)
+	errs := make([]error, 3)
+
+	// First caller: will enter sync.OnceValues() and load the value. We cancel its context shortly after.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		results[0], errs[0] = cacheWithLoader.GetOrWait(ctxFirst, mockDatasource, mockContext, "test-key")
+	}()
+
+	// Give the first caller time to enter sync.OnceValues()
+	time.Sleep(10 * time.Millisecond)
+
+	// Second and third callers: wait on sync.OnceValues(). Use separate new contexts which we don't cancel
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		results[1], errs[1] = cacheWithLoader.GetOrWait(context.Background(), mockDatasource, mockContext, "test-key")
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		results[2], errs[2] = cacheWithLoader.GetOrWait(context.Background(), mockDatasource, mockContext, "test-key")
+	}()
+
+	// Give the second and third callers time to wait on sync.OnceValues()
+	// Then cancel the first caller's context while loading is occuring
+	time.Sleep(10 * time.Millisecond)
+	cancelFirst()
+
+	wg.Wait()
+
+	// Without using WithoutCancel, the loader would see the cancelled context and return context.Canceled.
+	// This would propegate to all callers. Using WithoutCancel: the loader still completes and all callers get the value.
+	for i := 0; i < 3; i++ {
+		if errs[i] != nil {
+			t.Errorf("caller %d: expected no error, got %v", i, errs[i])
+		}
+		if results[i] != "loaded-value" {
+			t.Errorf("caller %d: expected loaded-value, got %q", i, results[i])
+		}
+	}
+}

--- a/pkg/plugin/cache_utils_test.go
+++ b/pkg/plugin/cache_utils_test.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -73,26 +74,26 @@ func TestTypedCache_WithStructKeys(t *testing.T) {
 func TestTypedCacheWithLoader_GetOrWait_CacheHit(t *testing.T) {
 	// Create a typed cache
 	cache := NewTypedCache[string, string](5*time.Minute, 10*time.Minute)
-	
+
 	// Pre-populate the cache
 	cache.Set("test-key", "cached-value")
-	
+
 	// Create a loader that should not be called
-	loader := func(d *SiftDatasource, ctx backend.PluginContext, key string) (string, error) {
+	loader := func(ctx context.Context, d *SiftDatasource, pCtx backend.PluginContext, key string) (string, error) {
 		t.Error("Loader should not be called when value is in cache")
 		return "", errors.New("should not be called")
 	}
-	
+
 	// Create cache with loader
 	cacheWithLoader := NewTypedCacheWithLoader(cache, loader, func(k string) string { return k })
-	
+
 	// Mock datasource and context
 	mockDatasource := &SiftDatasource{}
 	mockContext := backend.PluginContext{}
-	
+
 	// Test GetOrWait - should return cached value
-	result, err := cacheWithLoader.GetOrWait(mockDatasource, mockContext, "test-key")
-	
+	result, err := cacheWithLoader.GetOrWait(context.Background(), mockDatasource, mockContext, "test-key")
+
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -104,27 +105,27 @@ func TestTypedCacheWithLoader_GetOrWait_CacheHit(t *testing.T) {
 func TestTypedCacheWithLoader_GetOrWait_CacheMiss(t *testing.T) {
 	// Create an empty typed cache
 	cache := NewTypedCache[string, string](5*time.Minute, 10*time.Minute)
-	
+
 	// Create a loader that returns a value
 	loaderCalled := false
-	loader := func(d *SiftDatasource, ctx backend.PluginContext, key string) (string, error) {
+	loader := func(ctx context.Context, d *SiftDatasource, pCtx backend.PluginContext, key string) (string, error) {
 		loaderCalled = true
 		if key == "test-key" {
 			return "loaded-value", nil
 		}
 		return "", errors.New("unexpected key")
 	}
-	
+
 	// Create cache with loader
 	cacheWithLoader := NewTypedCacheWithLoader(cache, loader, func(k string) string { return k })
-	
+
 	// Mock datasource and context
 	mockDatasource := &SiftDatasource{}
 	mockContext := backend.PluginContext{}
-	
+
 	// Test GetOrWait - should call loader and return loaded value
-	result, err := cacheWithLoader.GetOrWait(mockDatasource, mockContext, "test-key")
-	
+	result, err := cacheWithLoader.GetOrWait(context.Background(), mockDatasource, mockContext, "test-key")
+
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -134,7 +135,7 @@ func TestTypedCacheWithLoader_GetOrWait_CacheMiss(t *testing.T) {
 	if !loaderCalled {
 		t.Error("Expected loader to be called")
 	}
-	
+
 	// Verify value was cached
 	cachedValue, found := cache.Get("test-key")
 	if !found {
@@ -148,30 +149,30 @@ func TestTypedCacheWithLoader_GetOrWait_CacheMiss(t *testing.T) {
 func TestTypedCacheWithLoader_GetOrWait_LoaderError(t *testing.T) {
 	// Create an empty typed cache
 	cache := NewTypedCache[string, string](5*time.Minute, 10*time.Minute)
-	
+
 	// Create a loader that returns an error
 	expectedError := errors.New("loader failed")
-	loader := func(d *SiftDatasource, ctx backend.PluginContext, key string) (string, error) {
+	loader := func(ctx context.Context, d *SiftDatasource, pCtx backend.PluginContext, key string) (string, error) {
 		return "", expectedError
 	}
-	
+
 	// Create cache with loader
 	cacheWithLoader := NewTypedCacheWithLoader(cache, loader, func(k string) string { return k })
-	
+
 	// Mock datasource and context
 	mockDatasource := &SiftDatasource{}
 	mockContext := backend.PluginContext{}
-	
+
 	// Test GetOrWait - should return error from loader
-	result, err := cacheWithLoader.GetOrWait(mockDatasource, mockContext, "test-key")
-	
+	result, err := cacheWithLoader.GetOrWait(context.Background(), mockDatasource, mockContext, "test-key")
+
 	if err != expectedError {
 		t.Errorf("Expected error %v, got %v", expectedError, err)
 	}
 	if result != "" {
 		t.Errorf("Expected empty result on error, got %s", result)
 	}
-	
+
 	// Verify value was not cached on error
 	_, found := cache.Get("test-key")
 	if found {
@@ -182,45 +183,45 @@ func TestTypedCacheWithLoader_GetOrWait_LoaderError(t *testing.T) {
 func TestTypedCacheWithLoader_GetOrWait_ConcurrentLoads(t *testing.T) {
 	// Create an empty typed cache
 	cache := NewTypedCache[string, string](5*time.Minute, 10*time.Minute)
-	
+
 	// Create a loader that simulates slow loading
 	loaderCallCount := 0
 	var loaderMutex sync.Mutex
-	loader := func(d *SiftDatasource, ctx backend.PluginContext, key string) (string, error) {
+	loader := func(ctx context.Context, d *SiftDatasource, pCtx backend.PluginContext, key string) (string, error) {
 		loaderMutex.Lock()
 		loaderCallCount++
 		loaderMutex.Unlock()
-		
+
 		// Simulate slow operation
 		time.Sleep(100 * time.Millisecond)
 		return "loaded-value", nil
 	}
-	
+
 	// Create cache with loader
 	cacheWithLoader := NewTypedCacheWithLoader(cache, loader, func(k string) string { return k })
-	
+
 	// Mock datasource and context
 	mockDatasource := &SiftDatasource{}
 	mockContext := backend.PluginContext{}
-	
+
 	// Launch multiple concurrent GetOrWait calls
 	const numGoroutines = 5
 	var wg sync.WaitGroup
 	results := make([]string, numGoroutines)
 	errors := make([]error, numGoroutines)
-	
+
 	for i := 0; i < numGoroutines; i++ {
 		wg.Add(1)
 		go func(index int) {
 			defer wg.Done()
-			result, err := cacheWithLoader.GetOrWait(mockDatasource, mockContext, "test-key")
+			result, err := cacheWithLoader.GetOrWait(context.Background(), mockDatasource, mockContext, "test-key")
 			results[index] = result
 			errors[index] = err
 		}(i)
 	}
-	
+
 	wg.Wait()
-	
+
 	// Verify all calls succeeded and returned the same value
 	for i := 0; i < numGoroutines; i++ {
 		if errors[i] != nil {
@@ -230,14 +231,14 @@ func TestTypedCacheWithLoader_GetOrWait_ConcurrentLoads(t *testing.T) {
 			t.Errorf("Goroutine %d got result %s, expected 'loaded-value'", i, results[i])
 		}
 	}
-	
+
 	// Verify loader was called only once despite multiple concurrent requests
 	loaderMutex.Lock()
 	if loaderCallCount != 1 {
 		t.Errorf("Expected loader to be called exactly once, but was called %d times", loaderCallCount)
 	}
 	loaderMutex.Unlock()
-	
+
 	// Verify value was cached
 	cachedValue, found := cache.Get("test-key")
 	if !found {
@@ -254,46 +255,46 @@ func TestTypedCacheWithLoader_GetOrWait_WithComplexTypes(t *testing.T) {
 		AssetID string
 		RunID   string
 	}
-	
+
 	type TestValue struct {
 		Data      string
 		Timestamp time.Time
 	}
-	
+
 	// Create cache with complex types
 	cache := NewTypedCache[string, TestValue](5*time.Minute, 10*time.Minute)
-	
+
 	// Create a loader
-	loader := func(d *SiftDatasource, ctx backend.PluginContext, key TestKey) (TestValue, error) {
+	loader := func(ctx context.Context, d *SiftDatasource, pCtx backend.PluginContext, key TestKey) (TestValue, error) {
 		return TestValue{
 			Data:      "complex-data-" + key.AssetID,
 			Timestamp: time.Now(),
 		}, nil
 	}
-	
+
 	// Key conversion function
 	keyToComparable := func(k TestKey) string {
 		return k.AssetID + ":" + k.RunID
 	}
-	
+
 	// Create cache with loader
 	cacheWithLoader := NewTypedCacheWithLoader(cache, loader, keyToComparable)
-	
+
 	// Mock datasource and context
 	mockDatasource := &SiftDatasource{}
 	mockContext := backend.PluginContext{}
-	
+
 	// Test with complex key
 	testKey := TestKey{AssetID: "asset123", RunID: "run456"}
-	result, err := cacheWithLoader.GetOrWait(mockDatasource, mockContext, testKey)
-	
+	result, err := cacheWithLoader.GetOrWait(context.Background(), mockDatasource, mockContext, testKey)
+
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
 	if result.Data != "complex-data-asset123" {
 		t.Errorf("Expected 'complex-data-asset123', got %s", result.Data)
 	}
-	
+
 	// Verify caching with the converted key
 	cachedValue, found := cache.Get("asset123:run456")
 	if !found {

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -186,7 +187,7 @@ func (d *SiftDatasource) QueryData(ctx context.Context, req *backend.QueryDataRe
 			continue
 		}
 
-		res := d.query(req.PluginContext, q, *fqm)
+		res := d.query(ctx, req.PluginContext, q, *fqm)
 		// save the response in a hashmap
 		// based on with RefID as identifier
 		response.Responses[q.RefID] = res
@@ -388,7 +389,7 @@ func getApiUrl(dataSourceInstanceSettings *backend.DataSourceInstanceSettings) (
 	return u, nil
 }
 
-func (d *SiftDatasource) query(pCtx backend.PluginContext, query backend.DataQuery, fqm queryModel) backend.DataResponse {
+func (d *SiftDatasource) query(ctx context.Context, pCtx backend.PluginContext, query backend.DataQuery, fqm queryModel) backend.DataResponse {
 	defer func() {
 		if err := recover(); err != nil {
 			log.DefaultLogger.Error("recovered from panic", "error", err)
@@ -397,20 +398,26 @@ func (d *SiftDatasource) query(pCtx backend.PluginContext, query backend.DataQue
 
 	// Route annotationsQuery to the Sift annotations API
 	if fqm.AnnotationType == "annotationsQuery" {
-		return d.querySiftAnnotations(pCtx, query, fqm)
+		return d.querySiftAnnotations(ctx, pCtx, query, fqm)
 	}
 
 	var response backend.DataResponse
 
 	queryStart := time.Now()
-	queries, calculatedChannelKeys, err := generateQueries(pCtx, fqm, d)
+	queries, calculatedChannelKeys, err := generateQueries(ctx, pCtx, fqm, d)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return backend.ErrDataResponse(backend.Status(499), "request cancelled") // 499 Client Closed Request
+		}
 		return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("error generating queries: %v", err.Error()))
 	}
 	afterLoadingQueries := time.Now()
 
-	responseData, err := runDataQueries(pCtx, queries, query, d)
+	responseData, err := runDataQueries(ctx, pCtx, queries, query, d)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return backend.ErrDataResponse(backend.Status(499), "request cancelled") // 499 Client Closed Request
+		}
 		return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("error generating getting data: %v", err.Error()))
 	}
 	afterExecutingQueries := time.Now()
@@ -446,7 +453,7 @@ func (d *SiftDatasource) query(pCtx backend.PluginContext, query backend.DataQue
 // - A slice of query objects that can be sent to the backend API
 // - A map of calculated channel keys to their metadata (for calculated channels only)
 // - Any error that occurred during query generation
-func generateQueries(pCtx backend.PluginContext, fqm queryModel, d *SiftDatasource) ([]siftApiGetDataSubQuery, map[string]calculatedChannelKey, error) {
+func generateQueries(ctx context.Context, pCtx backend.PluginContext, fqm queryModel, d *SiftDatasource) ([]siftApiGetDataSubQuery, map[string]calculatedChannelKey, error) {
 	queries := []siftApiGetDataSubQuery{}
 	calculatedChannelKeys := make(map[string]calculatedChannelKey)
 
@@ -460,14 +467,14 @@ func generateQueries(pCtx backend.PluginContext, fqm queryModel, d *SiftDatasour
 			if assetQuery.AssetId != "" {
 				assetIdQueries = append(assetIdQueries, assetQuery.AssetId)
 			} else if assetQuery.AssetName != "" {
-				foundAssetIds, err := d.getAssetIdsByName(pCtx, assetQuery.AssetName, assetQuery.NameAsRegex)
+				foundAssetIds, err := d.getAssetIdsByName(ctx, pCtx, assetQuery.AssetName, assetQuery.NameAsRegex)
 				if err != nil {
 					return nil, nil, fmt.Errorf("error looking up assets: %w", err)
 				}
 				assetIds = append(assetIds, foundAssetIds...)
 			}
 		}
-		validAssetIds, err := d.getValidAssetsById(pCtx, assetIdQueries)
+		validAssetIds, err := d.getValidAssetsById(ctx, pCtx, assetIdQueries)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error looking up assets: %w", err)
 		}
@@ -484,28 +491,28 @@ func generateQueries(pCtx backend.PluginContext, fqm queryModel, d *SiftDatasour
 			if runQuery.RunId != "" {
 				runIdQueries = append(runIdQueries, runQuery.RunId)
 			} else if runQuery.RunName != "" {
-				foundRunIds, err := d.getRunIdsByName(pCtx, assetIds, runQuery.RunName, runQuery.NameAsRegex)
+				foundRunIds, err := d.getRunIdsByName(ctx, pCtx, assetIds, runQuery.RunName, runQuery.NameAsRegex)
 				if err != nil {
 					return nil, nil, fmt.Errorf("error looking up runs: %w", err)
 				}
 				runIds = append(runIds, foundRunIds...)
 			}
 		}
-		validRunIds, err := d.getValidRunsById(pCtx, runIdQueries)
+		validRunIds, err := d.getValidRunsById(ctx, pCtx, runIdQueries)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error looking up runs: %w", err)
 		}
 		runIds = append(runIds, validRunIds...)
 
 		// Process regular channel queries
-		channelQueries, err := getChannelQueries(pCtx, cdq, runIds, assetIds, d)
+		channelQueries, err := getChannelQueries(ctx, pCtx, cdq, runIds, assetIds, d)
 		if err != nil {
 			return nil, nil, err
 		}
 		queries = append(queries, channelQueries...)
 
 		//Process calculated channel queries
-		calculationQueries, calculatedChanKeys, err := getCalculationQueries(pCtx, cdq, runIds, assetIds, fqm, d)
+		calculationQueries, calculatedChanKeys, err := getCalculationQueries(ctx, pCtx, cdq, runIds, assetIds, fqm, d)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -546,18 +553,18 @@ func splitQueries(queries []siftApiGetDataSubQuery, chunkSize int) [][]siftApiGe
 	return chunks
 }
 
-func runDataQueries(pCtx backend.PluginContext, queries []siftApiGetDataSubQuery, query backend.DataQuery, d *SiftDatasource) ([]queryResponseData, error) {
+func runDataQueries(ctx context.Context, pCtx backend.PluginContext, queries []siftApiGetDataSubQuery, query backend.DataQuery, d *SiftDatasource) ([]queryResponseData, error) {
 	chunks := splitQueries(queries, (len(queries)+maxParallelDataQueries-1)/maxParallelDataQueries)
 
 	var allData []queryResponseData
 	var mu sync.Mutex
 
-	g, _ := errgroup.WithContext(context.Background())
+	g, _ := errgroup.WithContext(ctx)
 	g.SetLimit(maxParallelDataQueries)
 	for _, chunk := range chunks {
 		chunk := chunk
 		g.Go(func() error {
-			dataResponse, err := d.getData(pCtx, chunk, query)
+			dataResponse, err := d.getData(ctx, pCtx, chunk, query)
 			if err != nil {
 				return err
 			}
@@ -1197,11 +1204,14 @@ func generateAnnotationFrame(responseData []queryResponseData, calculatedChannel
 
 // querySiftAnnotations handles the annotationsQuery type by calling the Sift annotations API
 // and converting the response into a Grafana-compatible annotation data frame.
-func (d *SiftDatasource) querySiftAnnotations(pCtx backend.PluginContext, query backend.DataQuery, fqm queryModel) backend.DataResponse {
+func (d *SiftDatasource) querySiftAnnotations(ctx context.Context, pCtx backend.PluginContext, query backend.DataQuery, fqm queryModel) backend.DataResponse {
 	var response backend.DataResponse
 
-	annotations, err := d.listSiftAnnotations(pCtx, query, fqm.AnnotationFilter)
+	annotations, err := d.listSiftAnnotations(ctx, pCtx, query, fqm.AnnotationFilter)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return backend.ErrDataResponse(backend.Status(499), "request cancelled") // 499 Client Closed Request
+		}
 		return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("error listing Sift annotations: %v", err.Error()))
 	}
 
@@ -1394,7 +1404,7 @@ func checkInt64PrecisionLoss(frame *data.Frame) {
 	}
 }
 
-func getChannelQueries(pCtx backend.PluginContext, cdq channelDataQuery, runIds []string, assetIds []string, d *SiftDatasource) ([]siftApiGetDataSubQuery, error) {
+func getChannelQueries(ctx context.Context, pCtx backend.PluginContext, cdq channelDataQuery, runIds []string, assetIds []string, d *SiftDatasource) ([]siftApiGetDataSubQuery, error) {
 	queries := []siftApiGetDataSubQuery{}
 	if cdq.ChannelQueries == nil {
 		return queries, nil
@@ -1429,7 +1439,7 @@ func getChannelQueries(pCtx backend.PluginContext, cdq channelDataQuery, runIds 
 					})
 				}
 			}
-			resultsExact, err := parallelSearchChannels(d, pCtx, channelNameExactSearches, 10, d.channelsNameSearchCache)
+			resultsExact, err := parallelSearchChannels(ctx, d, pCtx, channelNameExactSearches, 10, d.channelsNameSearchCache)
 			if err != nil {
 				return nil, fmt.Errorf("error looking up exact channels: %w", err)
 			}
@@ -1441,7 +1451,7 @@ func getChannelQueries(pCtx backend.PluginContext, cdq channelDataQuery, runIds 
 					}
 				}
 			}
-			resultsRegex, err := parallelSearchChannels(d, pCtx, channelNameRegexSearches, 10, d.channelsRegexSearchCache)
+			resultsRegex, err := parallelSearchChannels(ctx, d, pCtx, channelNameRegexSearches, 10, d.channelsRegexSearchCache)
 			if err != nil {
 				return nil, fmt.Errorf("error looking up regex channels: %w", err)
 			}
@@ -1456,7 +1466,7 @@ func getChannelQueries(pCtx backend.PluginContext, cdq channelDataQuery, runIds 
 		}
 	}
 
-	results, err := d.getChannelsById(pCtx, channelIdQueries)
+	results, err := d.getChannelsById(ctx, pCtx, channelIdQueries)
 	if err != nil {
 		return nil, fmt.Errorf("error looking up channels: %w", err)
 	}
@@ -1493,7 +1503,7 @@ func getChannelQueries(pCtx backend.PluginContext, cdq channelDataQuery, runIds 
 	return queries, nil
 }
 
-func getCalculationQueries(pCtx backend.PluginContext, cdq channelDataQuery, runIds []string, assetIds []string, fqm queryModel, d *SiftDatasource) ([]siftApiGetDataSubQuery, map[string]calculatedChannelKey, error) {
+func getCalculationQueries(ctx context.Context, pCtx backend.PluginContext, cdq channelDataQuery, runIds []string, assetIds []string, fqm queryModel, d *SiftDatasource) ([]siftApiGetDataSubQuery, map[string]calculatedChannelKey, error) {
 	queries := []siftApiGetDataSubQuery{}
 	calculatedChannelKeys := map[string]calculatedChannelKey{}
 	if cdq.CalculatedChannelQueries == nil {
@@ -1521,7 +1531,7 @@ func getCalculationQueries(pCtx backend.PluginContext, cdq channelDataQuery, run
 				if channelRef.ChannelId != "" {
 					var results []Channel
 					var err error
-					results, err = d.getChannelsById(pCtx, []string{channelRef.ChannelId})
+					results, err = d.getChannelsById(ctx, pCtx, []string{channelRef.ChannelId})
 					if err != nil {
 						return nil, nil, fmt.Errorf("error looking up channels: %w", err)
 					}
@@ -1542,9 +1552,9 @@ func getCalculationQueries(pCtx backend.PluginContext, cdq channelDataQuery, run
 					var channels []Channel
 					var err error
 					if channelRef.NameAsRegex {
-						channels, err = d.channelsRegexSearchCache.GetOrWait(d, pCtx, channelSearchKey{assetId: assetId, searchTerm: channelRef.ChannelName})
+						channels, err = d.channelsRegexSearchCache.GetOrWait(ctx, d, pCtx, channelSearchKey{assetId: assetId, searchTerm: channelRef.ChannelName})
 					} else {
-						channels, err = d.channelsNameSearchCache.GetOrWait(d, pCtx, channelSearchKey{assetId: assetId, searchTerm: channelRef.ChannelName})
+						channels, err = d.channelsNameSearchCache.GetOrWait(ctx, d, pCtx, channelSearchKey{assetId: assetId, searchTerm: channelRef.ChannelName})
 					}
 
 					if err != nil || channels == nil {
@@ -1686,13 +1696,14 @@ func getCalculationQueries(pCtx backend.PluginContext, cdq channelDataQuery, run
 }
 
 func parallelSearchChannels(
+	ctx context.Context,
 	d *SiftDatasource,
 	pCtx backend.PluginContext,
 	channelSearchKeys []channelSearchKey,
 	maxParallel int,
 	cacheWithLoader *TypedCacheWithLoader[channelSearchKey, []Channel, string],
 ) (map[channelSearchKey][]Channel, error) {
-	g, _ := errgroup.WithContext(context.Background())
+	g, _ := errgroup.WithContext(ctx)
 	sem := make(chan struct{}, maxParallel)
 	results := make(map[channelSearchKey][]Channel)
 	mu := sync.Mutex{}
@@ -1702,7 +1713,7 @@ func parallelSearchChannels(
 		g.Go(func() error {
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			result, err := cacheWithLoader.GetOrWait(d, pCtx, key)
+			result, err := cacheWithLoader.GetOrWait(ctx, d, pCtx, key)
 			if err != nil {
 				return err
 			}

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -559,12 +559,14 @@ func runDataQueries(ctx context.Context, pCtx backend.PluginContext, queries []s
 	var allData []queryResponseData
 	var mu sync.Mutex
 
-	g, _ := errgroup.WithContext(ctx)
+	// We pass the error group context to allow us to fail fast if any of the chunks fail
+	// versus waiting for all chunks to complete and then returning the error.
+	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(maxParallelDataQueries)
 	for _, chunk := range chunks {
 		chunk := chunk
 		g.Go(func() error {
-			dataResponse, err := d.getData(ctx, pCtx, chunk, query)
+			dataResponse, err := d.getData(gCtx, pCtx, chunk, query)
 			if err != nil {
 				return err
 			}
@@ -1703,7 +1705,9 @@ func parallelSearchChannels(
 	maxParallel int,
 	cacheWithLoader *TypedCacheWithLoader[channelSearchKey, []Channel, string],
 ) (map[channelSearchKey][]Channel, error) {
-	g, _ := errgroup.WithContext(ctx)
+	// We pass the error group context to allow us to fail fast if any of the chunks fail
+	// versus waiting for all chunks to complete and then returning the error.
+	g, gCtx := errgroup.WithContext(ctx)
 	sem := make(chan struct{}, maxParallel)
 	results := make(map[channelSearchKey][]Channel)
 	mu := sync.Mutex{}
@@ -1713,7 +1717,7 @@ func parallelSearchChannels(
 		g.Go(func() error {
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			result, err := cacheWithLoader.GetOrWait(ctx, d, pCtx, key)
+			result, err := cacheWithLoader.GetOrWait(gCtx, d, pCtx, key)
 			if err != nil {
 				return err
 			}

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -1836,7 +1837,7 @@ func (s *DatasourceTestSuite) TestGenerateQueries() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			queries, channelKeys, err := generateQueries(s.pCtx, tc.input, s.datasource)
+			queries, channelKeys, err := generateQueries(context.Background(), s.pCtx, tc.input, s.datasource)
 
 			if tc.expectedError != "" {
 				s.Error(err)

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -34,7 +34,7 @@ func (d *SiftDatasource) callResourceAssets(ctx context.Context, req *backend.Ca
 		}
 	}
 
-	assets, err := handlePaginatedRequest[Asset](d, apiRequest{
+	assets, err := handlePaginatedRequest[Asset](ctx, d, apiRequest{
 		pCtx:        req.PluginContext,
 		method:      "GET",
 		path:        "/api/v1/assets",
@@ -70,7 +70,7 @@ func (d *SiftDatasource) callResourceRuns(ctx context.Context, req *backend.Call
 		return err
 	}
 
-	runs, err := handlePaginatedRequest[Run](d, apiRequest{
+	runs, err := handlePaginatedRequest[Run](ctx, d, apiRequest{
 		pCtx:        req.PluginContext,
 		method:      "GET",
 		path:        "/api/v2/runs",
@@ -122,7 +122,7 @@ func (d *SiftDatasource) callResourceChannels(ctx context.Context, req *backend.
 
 	params.Set("page_size", strconv.Itoa(ResourceLimit))
 
-	channels, err := handlePaginatedRequest[Channel](d, apiRequest{
+	channels, err := handlePaginatedRequest[Channel](ctx, d, apiRequest{
 		pCtx:        req.PluginContext,
 		method:      "GET",
 		path:        "/api/v1/channels:search", // internal API endpoint used here for improved regex search performance
@@ -188,7 +188,7 @@ func (d *SiftDatasource) resolveQueryToSiftMetadata(ctx context.Context, req *ba
 		})
 	}
 
-	queries, calculatedKeys, err := generateQueries(req.PluginContext, *queryModel, d)
+	queries, calculatedKeys, err := generateQueries(ctx, req.PluginContext, *queryModel, d)
 	if err != nil {
 		log.DefaultLogger.Error("resolveQueryToSiftMetadata generateQueries error", "error", err)
 		return sender.Send(&backend.CallResourceResponse{
@@ -273,7 +273,7 @@ func (d *SiftDatasource) resolveQueryToSiftMetadata(ctx context.Context, req *ba
 	}
 
 	if len(channelIDs) > 0 {
-		channels, err := d.getChannelsById(req.PluginContext, channelIDs)
+		channels, err := d.getChannelsById(ctx, req.PluginContext, channelIDs)
 		if err != nil {
 			log.DefaultLogger.Error("resolveQueryToSiftMetadata channel lookup error", "error", err)
 			return sender.Send(&backend.CallResourceResponse{

--- a/pkg/plugin/sift_api_queries.go
+++ b/pkg/plugin/sift_api_queries.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -126,7 +127,10 @@ type siftApiGetDataQuery struct {
 	PageToken *string                  `json:"pageToken,omitempty"`
 }
 
-func (d *SiftDatasource) executeRequest(req apiRequest) ([]byte, error) {
+func (d *SiftDatasource) executeRequest(ctx context.Context, req apiRequest) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	apiKey := req.pCtx.DataSourceInstanceSettings.DecryptedSecureJSONData["apiKey"]
 
 	u, err := getApiUrl(req.pCtx.DataSourceInstanceSettings)
@@ -148,7 +152,7 @@ func (d *SiftDatasource) executeRequest(req apiRequest) ([]byte, error) {
 		bodyReader = bytes.NewReader(bodyBytes)
 	}
 
-	httpReq, err := http.NewRequest(req.method, u.String(), bodyReader)
+	httpReq, err := http.NewRequestWithContext(ctx, req.method, u.String(), bodyReader)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}
@@ -180,11 +184,12 @@ func (d *SiftDatasource) executeRequest(req apiRequest) ([]byte, error) {
 }
 
 func handleRequest[T any](
+	ctx context.Context,
 	d *SiftDatasource,
 	req apiRequest,
 	unmarshal func(respBody []byte) (items []T, nextPageToken string, err error),
 ) (items []T, nextPageToken string, err error) {
-	respBody, err := d.executeRequest(req)
+	respBody, err := d.executeRequest(ctx, req)
 	if err != nil {
 		return nil, "", err
 	}
@@ -198,6 +203,7 @@ func handleRequest[T any](
 }
 
 func handlePaginatedRequest[T any](
+	ctx context.Context,
 	d *SiftDatasource,
 	req apiRequest,
 	pageSize int,
@@ -210,7 +216,10 @@ func handlePaginatedRequest[T any](
 	params.Set("page_size", strconv.Itoa(pageSize))
 
 	for i := 0; i < maxPages; i++ {
-		items, nextPageToken, err := handleRequest[T](d, req, unmarshal)
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		items, nextPageToken, err := handleRequest[T](ctx, d, req, unmarshal)
 		if err != nil {
 			return nil, err
 		}
@@ -226,7 +235,7 @@ func handlePaginatedRequest[T any](
 
 	return results, nil
 }
-func (d *SiftDatasource) listSiftAnnotations(pCtx backend.PluginContext, query backend.DataQuery, filter string) ([]SiftAnnotation, error) {
+func (d *SiftDatasource) listSiftAnnotations(ctx context.Context, pCtx backend.PluginContext, query backend.DataQuery, filter string) ([]SiftAnnotation, error) {
 	params := url.Values{}
 
 	// Build time filter using CEL
@@ -240,7 +249,7 @@ func (d *SiftDatasource) listSiftAnnotations(pCtx backend.PluginContext, query b
 		params.Set("filter", timeFilter)
 	}
 
-	annotations, err := handlePaginatedRequest[SiftAnnotation](d, apiRequest{
+	annotations, err := handlePaginatedRequest[SiftAnnotation](ctx, d, apiRequest{
 		pCtx:        pCtx,
 		method:      "GET",
 		path:        "/api/v1/annotations",
@@ -260,7 +269,7 @@ func (d *SiftDatasource) listSiftAnnotations(pCtx backend.PluginContext, query b
 	return annotations, nil
 }
 
-func (d *SiftDatasource) getData(pCtx backend.PluginContext, subQueries []siftApiGetDataSubQuery, query backend.DataQuery) ([]queryResponseData, error) {
+func (d *SiftDatasource) getData(ctx context.Context, pCtx backend.PluginContext, subQueries []siftApiGetDataSubQuery, query backend.DataQuery) ([]queryResponseData, error) {
 	backendQuery := siftApiGetDataQuery{
 		Queries:   subQueries,
 		StartTime: query.TimeRange.From.Format(time.RFC3339Nano),
@@ -271,6 +280,9 @@ func (d *SiftDatasource) getData(pCtx backend.PluginContext, subQueries []siftAp
 
 	var responseData []queryResponseData
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		req := apiRequest{
 			pCtx:   pCtx,
 			method: "POST",
@@ -278,7 +290,7 @@ func (d *SiftDatasource) getData(pCtx backend.PluginContext, subQueries []siftAp
 			body:   backendQuery,
 		}
 
-		respBody, err := d.executeRequest(req)
+		respBody, err := d.executeRequest(ctx, req)
 		if err != nil {
 			return nil, err
 		}
@@ -302,7 +314,7 @@ func (d *SiftDatasource) getData(pCtx backend.PluginContext, subQueries []siftAp
 	return responseData, nil
 }
 
-func (d *SiftDatasource) getValidAssetsById(pCtx backend.PluginContext, assetIds []string) ([]string, error) {
+func (d *SiftDatasource) getValidAssetsById(ctx context.Context, pCtx backend.PluginContext, assetIds []string) ([]string, error) {
 	// TODO: client key support once backend supports it
 	startTime := time.Now()
 
@@ -326,7 +338,7 @@ func (d *SiftDatasource) getValidAssetsById(pCtx backend.PluginContext, assetIds
 	assetFilter := celUtils.In("asset_id", assetIdsToSearch)
 	params.Set("filter", assetFilter)
 
-	assets, err := handlePaginatedRequest[Asset](d, apiRequest{
+	assets, err := handlePaginatedRequest[Asset](ctx, d, apiRequest{
 		pCtx:        pCtx,
 		method:      "GET",
 		path:        "/api/v1/assets",
@@ -360,7 +372,7 @@ func (d *SiftDatasource) getValidAssetsById(pCtx backend.PluginContext, assetIds
 	return validAssetIds, nil
 }
 
-func (d *SiftDatasource) getAssetIdsByName(pCtx backend.PluginContext, assetName string, asRegex bool) ([]string, error) {
+func (d *SiftDatasource) getAssetIdsByName(ctx context.Context, pCtx backend.PluginContext, assetName string, asRegex bool) ([]string, error) {
 	startTime := time.Now()
 
 	if asRegex {
@@ -384,7 +396,7 @@ func (d *SiftDatasource) getAssetIdsByName(pCtx backend.PluginContext, assetName
 	}
 	params.Set("filter", assetFilter)
 
-	assets, err := handlePaginatedRequest[Asset](d, apiRequest{
+	assets, err := handlePaginatedRequest[Asset](ctx, d, apiRequest{
 		pCtx:        pCtx,
 		method:      "GET",
 		path:        "/api/v1/assets",
@@ -424,7 +436,7 @@ func (d *SiftDatasource) getAssetIdsByName(pCtx backend.PluginContext, assetName
 	return assetIds, nil
 }
 
-func (d *SiftDatasource) getValidRunsById(pCtx backend.PluginContext, runIdOrClientKeys []string) ([]string, error) {
+func (d *SiftDatasource) getValidRunsById(ctx context.Context, pCtx backend.PluginContext, runIdOrClientKeys []string) ([]string, error) {
 	startTime := time.Now()
 
 	cachedRunIds := []string{}
@@ -447,7 +459,7 @@ func (d *SiftDatasource) getValidRunsById(pCtx backend.PluginContext, runIdOrCli
 	runFilter := celUtils.Or(celUtils.In("client_key", runIdOrClientKeysToSearch), celUtils.In("run_id", runIdOrClientKeysToSearch))
 	params.Set("filter", runFilter)
 
-	runs, err := handlePaginatedRequest[Run](d, apiRequest{
+	runs, err := handlePaginatedRequest[Run](ctx, d, apiRequest{
 		pCtx:        pCtx,
 		method:      "GET",
 		path:        "/api/v2/runs",
@@ -480,7 +492,7 @@ func (d *SiftDatasource) getValidRunsById(pCtx backend.PluginContext, runIdOrCli
 	return validRunIds, nil
 }
 
-func (d *SiftDatasource) getRunIdsByName(pCtx backend.PluginContext, assetIds []string, runName string, asRegex bool) ([]string, error) {
+func (d *SiftDatasource) getRunIdsByName(ctx context.Context, pCtx backend.PluginContext, assetIds []string, runName string, asRegex bool) ([]string, error) {
 	startTime := time.Now()
 
 	if asRegex {
@@ -504,7 +516,7 @@ func (d *SiftDatasource) getRunIdsByName(pCtx backend.PluginContext, assetIds []
 	}
 	params.Set("filter", runFilter)
 
-	runs, err := handlePaginatedRequest[Run](d, apiRequest{
+	runs, err := handlePaginatedRequest[Run](ctx, d, apiRequest{
 		pCtx:        pCtx,
 		method:      "GET",
 		path:        "/api/v2/runs",
@@ -540,7 +552,7 @@ func (d *SiftDatasource) getRunIdsByName(pCtx backend.PluginContext, assetIds []
 	return runIds, nil
 }
 
-func (d *SiftDatasource) getChannelsById(pCtx backend.PluginContext, channelIds []string) ([]Channel, error) {
+func (d *SiftDatasource) getChannelsById(ctx context.Context, pCtx backend.PluginContext, channelIds []string) ([]Channel, error) {
 	startTime := time.Now()
 
 	cachedChannels := []Channel{}
@@ -563,7 +575,7 @@ func (d *SiftDatasource) getChannelsById(pCtx backend.PluginContext, channelIds 
 	channelFilter := celUtils.In("channel_id", channelIdsToSearch)
 	params.Set("filter", channelFilter)
 
-	channels, err := handlePaginatedRequest[Channel](d, apiRequest{
+	channels, err := handlePaginatedRequest[Channel](ctx, d, apiRequest{
 		pCtx:        pCtx,
 		method:      "GET",
 		path:        "/api/v3/channels",
@@ -595,7 +607,7 @@ func (d *SiftDatasource) getChannelsById(pCtx backend.PluginContext, channelIds 
 }
 
 // getChannelsByNameSearch - search for channels by regex query. Does not use cache and is intended to be used by the TypedCacheWithLoader
-func getChannelsByNameSearch(d *SiftDatasource, pCtx backend.PluginContext, query channelSearchKey) ([]Channel, error) {
+func getChannelsByNameSearch(ctx context.Context, d *SiftDatasource, pCtx backend.PluginContext, query channelSearchKey) ([]Channel, error) {
 	startTime := time.Now()
 
 	params := url.Values{}
@@ -604,7 +616,7 @@ func getChannelsByNameSearch(d *SiftDatasource, pCtx backend.PluginContext, quer
 	params.Set("assetIds", query.assetId)
 	params.Set("searchTerm", query.searchTerm)
 
-	channels, err := handlePaginatedRequest[Channel](d, apiRequest{
+	channels, err := handlePaginatedRequest[Channel](ctx, d, apiRequest{
 		pCtx:        pCtx,
 		method:      "GET",
 		path:        "/api/v1/channels:search", // internal API endpoint used here for improved regex search performance
@@ -635,14 +647,14 @@ func getChannelsByNameSearch(d *SiftDatasource, pCtx backend.PluginContext, quer
 }
 
 // getChannelsByNameExact - search for channels by exact name query. Does not use cache and is intended to be used by the TypedCacheWithLoader
-func getChannelsByNameExact(d *SiftDatasource, pCtx backend.PluginContext, query channelSearchKey) ([]Channel, error) {
+func getChannelsByNameExact(ctx context.Context, d *SiftDatasource, pCtx backend.PluginContext, query channelSearchKey) ([]Channel, error) {
 	startTime := time.Now()
 
 	params := url.Values{}
 	channelFilter := celUtils.And(celUtils.Equals("asset_id", query.assetId), celUtils.Equals("name", query.searchTerm))
 	params.Set("filter", channelFilter)
 
-	channels, err := handlePaginatedRequest[Channel](d, apiRequest{
+	channels, err := handlePaginatedRequest[Channel](ctx, d, apiRequest{
 		pCtx:        pCtx,
 		method:      "GET",
 		path:        "/api/v3/channels",


### PR DESCRIPTION
## Description

Currently, when a cancellation request is made while querying data, the cancellation does not flow down to the actual data queries being performed. This can lead to concurrent requests being performed, and unexpected behavior.

We now pass the request context throughout the query call stack, and properly propagate any cancellation signals.


**Verification**
Queried 90 days of data, then canceled the query using the UI. Then made a second query for a shorter period of time.


Current plugin. A cancellation request appears in the logs, but isn't handled by the initial query. The initial query results return after the second query has completed
```
# Initial query
sift-grafana-datasource  | logger=datasources t=2026-02-26T20:21:57.518750335Z level=debug msg="Querying for data source via SQL store" uid=P5B56D21E16392E86 orgId=1
sift-grafana-datasource  | logger=query_data t=2026-02-26T20:21:57.522806133Z level=debug msg="Processed metrics query" ref_id=A from=1764361317506 to=1772137317506 interval=3600000 max_data_points=2197 query="{\"annotationFilter\":\"\",\"annotationType\":\"\",\"channelDataQueries\":[{\"assetQueries\":[{\"asSelect\":true,REDACTED_ASSET_AND_CHANNELS,\"runQueries\":[]}],\"combineRuns\":true,\"datasource\":{\"type\":\"sift-grafana-datasource\",\"uid\":\"P5B56D21E16392E86\"},\"datasourceId\":1,\"enumDisplay\":\"\",\"hide\":false,\"intervalMs\":3600000,\"key\":\"\",\"maxDataPoints\":2197,\"queryType\":\"\",\"queryVersion\":\"2.1\",\"refId\":\"A\"}"
sift-grafana-datasource  | logger=plugin.sift-grafana-datasource t=2026-02-26T20:21:57.527023848Z level=debug msg="Plugin Request Started" dsUid=P5B56D21E16392E86 endpoint=queryData uname= pluginVersion=1.4.1 dsName=Sift pluginId=sift-grafana-datasource
# Canceled query
sift-grafana-datasource  | logger=context userId=0 orgId=1 uname= t=2026-02-26T20:22:00.397233048Z level=error msg="Internal server error" error="[plugin.downstreamError] client: failed to query data: Failed to query data: rpc error: code = Canceled desc = context canceled" remote_addr=192.168.107.1 traceID=
sift-grafana-datasource  | logger=context userId=0 orgId=1 uname= t=2026-02-26T20:22:00.397353924Z level=error msg="Request Completed" method=POST path=/api/ds/query status=500 remote_addr=192.168.107.1 time_ms=2885 duration=2.885939016s size=116 referer="http://localhost:3005/d/ad5xnfj/new-dashboard?from=now-90d&orgId=1&to=now" handler=/api/ds/query status_source=downstream
# Short second query
sift-grafana-datasource  | logger=datasources t=2026-02-26T20:22:02.672028685Z level=debug msg="Querying for data source via SQL store" uid=P5B56D21E16392E86 orgId=1
sift-grafana-datasource  | logger=query_data t=2026-02-26T20:22:02.67541444Z level=debug msg="Processed metrics query" ref_id=A from=1772137022655 to=1772137322655 interval=100 max_data_points=2197 query="{\"annotationFilter\":\"\",\"annotationType\":\"\",\"channelDataQueries\":[{\"assetQueries\":[{\"asSelect\":true,REDACTED_ASSET_AND_CHANNELS,\"runQueries\":[]}],\"combineRuns\":true,\"datasource\":{\"type\":\"sift-grafana-datasource\",\"uid\":\"P5B56D21E16392E86\"},\"datasourceId\":1,\"enumDisplay\":\"\",\"hide\":false,\"intervalMs\":100,\"key\":\"\",\"maxDataPoints\":2197,\"queryType\":\"\",\"queryVersion\":\"2.1\",\"refId\":\"A\"}"
sift-grafana-datasource  | logger=plugin.sift-grafana-datasource t=2026-02-26T20:22:02.68321416Z level=debug msg="Plugin Request Started" dsName=Sift pluginId=sift-grafana-datasource pluginVersion=1.4.1 uname= dsUid=P5B56D21E16392E86 endpoint=queryData
# Second query completed
sift-grafana-datasource  | logger=plugin.sift-grafana-datasource t=2026-02-26T20:22:02.965634169Z level=debug msg=timings gettingData=270 loadingQueries=0 generatingDataFrame=5
sift-grafana-datasource  | logger=plugin.sift-grafana-datasource t=2026-02-26T20:22:02.966083378Z level=info msg="Plugin Request Completed" duration=276.783959ms endpoint=queryData statusSource=plugin uname= dsUid=P5B56D21E16392E86 dsName=Sift pluginId=sift-grafana-datasource pluginVersion=1.4.1 status=ok
# First query completed (completes successfully despite cancellation)
sift-grafana-datasource  | logger=plugin.sift-grafana-datasource t=2026-02-26T20:22:08.239350992Z level=debug msg=timings generatingDataFrame=27 gettingData=10682 loadingQueries=0
sift-grafana-datasource  | logger=plugin.sift-grafana-datasource t=2026-02-26T20:22:08.239468326Z level=info msg="Plugin Request Completed" duration=10.711388435s pluginId=sift-grafana-datasource pluginVersion=1.4.1 status=ok dsName=Sift dsUid=P5B56D21E16392E86 endpoint=queryData statusSource=plugin uname=

```


With the changes from this PR, the original query is fully canceled upon request. The next query performs as expected
```
# Initial query
sift-grafana-datasource  | logger=datasources t=2026-02-26T20:26:59.395109632Z level=debug msg="Querying for data source via SQL store" uid=P5B56D21E16392E86 orgId=1
sift-grafana-datasource  | logger=query_data t=2026-02-26T20:26:59.396381389Z level=debug msg="Processed metrics query" ref_id=A from=1764361619377 to=1772137619377 interval=3600000 max_data_points=2197 query="{\"annotationFilter\":\"\",\"annotationType\":\"\",\"channelDataQueries\":[{\"assetQueries\":[{\"asSelect\":true,REDACTED_ASSET_AND_CHANNELS,\"runQueries\":[]}],\"combineRuns\":true,\"datasource\":{\"type\":\"sift-grafana-datasource\",\"uid\":\"P5B56D21E16392E86\"},\"datasourceId\":1,\"enumDisplay\":\"\",\"hide\":false,\"intervalMs\":3600000,\"key\":\"\",\"maxDataPoints\":2197,\"queryType\":\"\",\"queryVersion\":\"2.1\",\"refId\":\"A\"}"
sift-grafana-datasource  | logger=plugin.sift-grafana-datasource t=2026-02-26T20:26:59.405590065Z level=debug msg="Plugin Request Started" pluginVersion=1.4.1 dsName=Sift dsUid=P5B56D21E16392E86 pluginId=sift-grafana-datasource endpoint=queryData uname=
# Canceled query
sift-grafana-datasource  | logger=context userId=0 orgId=1 uname= t=2026-02-26T20:27:02.129853602Z level=error msg="Internal server error" error="[plugin.downstreamError] client: failed to query data: Failed to query data: rpc error: code = Canceled desc = context canceled" remote_addr=192.168.107.1 traceID=
sift-grafana-datasource  | logger=context userId=0 orgId=1 uname= t=2026-02-26T20:27:02.130179604Z level=error msg="Request Completed" method=POST path=/api/ds/query status=500 remote_addr=192.168.107.1 time_ms=2743 duration=2.743722145s size=116 referer="http://localhost:3005/d/ad5xnfj/new-dashboard?from=now-90d&orgId=1&to=now" handler=/api/ds/query status_source=downstream
# First query completed (failure due to cancellation)
sift-grafana-datasource  | logger=plugin.sift-grafana-datasource t=2026-02-26T20:27:02.168226523Z level=error msg="Partial data response error" statusSource=plugin dsName=Sift dsUid=P5B56D21E16392E86 pluginId=sift-grafana-datasource refID=A error="request cancelled" uname= endpoint=queryData pluginVersion=1.4.1 status=499
sift-grafana-datasource  | logger=plugin.sift-grafana-datasource t=2026-02-26T20:27:02.168321816Z level=error msg="Plugin Request Completed" dsUid=P5B56D21E16392E86 duration=2.762207956s endpoint=queryData pluginId=sift-grafana-datasource pluginVersion=1.4.1 uname= status=error statusSource=plugin dsName=Sift
# Second query
sift-grafana-datasource  | logger=query_data t=2026-02-26T20:27:04.178537723Z level=debug msg="Processed metrics query" ref_id=A from=1772137324166 to=1772137624166 interval=100 max_data_points=2197 query="{\"annotationFilter\":\"\",\"annotationType\":\"\",\"channelDataQueries\":[{\"assetQueries\":[{\"asSelect\":true,REDACTED_ASSET_AND_CHANNELS,\"runQueries\":[]}],\"combineRuns\":true,\"datasource\":{\"type\":\"sift-grafana-datasource\",\"uid\":\"P5B56D21E16392E86\"},\"datasourceId\":1,\"enumDisplay\":\"\",\"hide\":false,\"intervalMs\":100,\"key\":\"\",\"maxDataPoints\":2197,\"queryType\":\"\",\"queryVersion\":\"2.1\",\"refId\":\"A\"}"
sift-grafana-datasource  | logger=plugin.sift-grafana-datasource t=2026-02-26T20:27:04.186083807Z level=debug msg="Plugin Request Started" endpoint=queryData pluginVersion=1.4.1 uname= dsName=Sift dsUid=P5B56D21E16392E86 pluginId=sift-grafana-datasource
# Second query completes
sift-grafana-datasource  | logger=plugin.sift-grafana-datasource t=2026-02-26T20:27:04.502243395Z level=debug msg=timings generatingDataFrame=1 gettingData=315 loadingQueries=0
sift-grafana-datasource  | logger=plugin.sift-grafana-datasource t=2026-02-26T20:27:04.502469354Z level=info msg="Plugin Request Completed" endpoint=queryData pluginId=sift-grafana-datasource pluginVersion=1.4.1 statusSource=plugin dsName=Sift dsUid=P5B56D21E16392E86 uname= duration=317.293511ms status=ok
```