### PR TITLE
Fix: update sharelink url format for e2

### DIFF
--- a/src/components/VisualSiftQueryEditor.test.tsx
+++ b/src/components/VisualSiftQueryEditor.test.tsx
@@ -80,6 +80,7 @@ describe('VisualSiftQueryEditor', () => {
       expect(openInSiftButtonProps).toMatchObject({
         apiBaseUrl: 'https://sift.example.com',
         frontendUrl: undefined,
+        queryType: QueryTypes.CHANNEL,
       });
     });
 
@@ -109,6 +110,11 @@ describe('VisualSiftQueryEditor', () => {
         expect(screen.getByText('Calculated Channels')).toBeInTheDocument();
         const radioButton = screen.getByLabelText('Calculated Channels');
         expect(radioButton).toBeChecked();
+      });
+
+      const openInSiftButtonProps = (OpenInSiftButton as jest.Mock).mock.calls.at(-1)?.[0];
+      expect(openInSiftButtonProps).toMatchObject({
+        queryType: QueryTypes.CALCULATED_CHANNEL,
       });
     });
 
@@ -467,6 +473,7 @@ describe('VisualSiftQueryEditor', () => {
             from: fromDate.toISOString(),
             to: toDate.toISOString(),
           },
+          queryType: QueryTypes.CHANNEL,
         }),
         expect.anything()
       );
@@ -509,6 +516,7 @@ describe('VisualSiftQueryEditor', () => {
             from: fromIsoString,
             to: toIsoString,
           },
+          queryType: QueryTypes.CHANNEL,
         }),
         expect.anything()
       );
@@ -540,6 +548,7 @@ describe('VisualSiftQueryEditor', () => {
       expect(OpenInSiftButton).toHaveBeenCalledWith(
         expect.objectContaining({
           timeRange: undefined,
+          queryType: QueryTypes.CHANNEL,
         }),
         expect.anything()
       );

--- a/src/components/VisualSiftQueryEditor.tsx
+++ b/src/components/VisualSiftQueryEditor.tsx
@@ -164,6 +164,7 @@ export const VisualSiftQueryEditor = (props: Props) => {
           apiBaseUrl={apiRestUrl}
           frontendUrl={frontendUrl}
           timeRange={shareLinkTimeRange}
+          queryType={queryMode}
         />
 
       </InlineFieldRow>

--- a/src/components/sharelink/OpenInSiftButton.test.tsx
+++ b/src/components/sharelink/OpenInSiftButton.test.tsx
@@ -4,6 +4,7 @@ import { OpenInSiftButton } from './OpenInSiftButton';
 import { generateLinkFromQuery } from './generateLinkFromQuery';
 import { getFrontendHostnameDefaults } from './getFrontendHostnameDefaults';
 import { getAppEvents } from '@grafana/runtime';
+import { QueryTypes } from '../../types';
 
 jest.mock('./generateLinkFromQuery', () => ({
   generateLinkFromQuery: jest.fn(),
@@ -26,12 +27,14 @@ const getAppEventsMock = getAppEvents as jest.MockedFunction<typeof getAppEvents
 describe('OpenInSiftButton', () => {
   let logSpy: jest.SpyInstance;
   let errorSpy: jest.SpyInstance;
+  let publishMock: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    generateLinkFromQueryMock.mockReturnValue('https://sift.example.com/explorer');
+    generateLinkFromQueryMock.mockReturnValue('https://sift.example.com/explore?method=single');
     getFrontendHostnameDefaultsMock.mockReturnValue('sift.example.com');
-    getAppEventsMock.mockReturnValue(null as any);
+    publishMock = jest.fn();
+    getAppEventsMock.mockReturnValue({ publish: publishMock } as any);
     logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
@@ -64,7 +67,7 @@ describe('OpenInSiftButton', () => {
     const button = screen.getByRole('button', { name: 'Open in Sift' });
     fireEvent.click(button);
 
-    expect(openSpy).toHaveBeenCalledWith('https://sift.example.com/explorer', '_blank', 'noopener,noreferrer');
+    expect(openSpy).toHaveBeenCalledWith('https://sift.example.com/explore?method=single', '_blank', 'noopener,noreferrer');
     openSpy.mockRestore();
   });
 
@@ -96,7 +99,7 @@ describe('OpenInSiftButton', () => {
     const button = screen.getByRole('button', { name: 'Open in Sift' });
     fireEvent.click(button);
 
-    expect(openSpy).toHaveBeenCalledWith('https://sift.example.com/explorer', '_blank', 'noopener,noreferrer');
+    expect(openSpy).toHaveBeenCalledWith('https://sift.example.com/explore?method=single', '_blank', 'noopener,noreferrer');
     openSpy.mockRestore();
   });
 
@@ -148,7 +151,7 @@ describe('OpenInSiftButton', () => {
     const button = screen.getByRole('button', { name: 'Open in Sift' });
     fireEvent.click(button);
 
-    expect(openSpy).toHaveBeenCalledWith('https://sift.example.com/explorer', '_blank', 'noopener,noreferrer');
+    expect(openSpy).toHaveBeenCalledWith('https://sift.example.com/explore?method=single', '_blank', 'noopener,noreferrer');
     openSpy.mockRestore();
   });
 
@@ -251,6 +254,41 @@ describe('OpenInSiftButton', () => {
     render(<OpenInSiftButton items={items} apiBaseUrl="https://unknown-api.example.com" />);
 
     expect(getFrontendHostnameDefaultsMock).toHaveBeenCalledWith('https://unknown-api.example.com');
+    expect(generateLinkFromQueryMock).not.toHaveBeenCalled();
+
+    const menuButton = screen.getByRole('button', { name: 'Open in Sift' });
+    expect(menuButton).toHaveAttribute('aria-disabled', 'true');
+
+    fireEvent.contextMenu(menuButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('menuitem', { name: /Open Link/i })).toBeDisabled();
+    });
+  });
+
+  it('disables share link when Query Mode is set to Calculated Channels', async () => {
+    const items = {
+      channelIds: ['channel-1'],
+      assetIds: ['asset-1'],
+      runIds: ['run-1'],
+      calculatedChannels: [
+        {
+          name: 'calc-1',
+          sourceChannels: ['channel-1'],
+          expression: '$1',
+          expressionDataType: 'double',
+        },
+      ],
+    };
+
+    render(
+      <OpenInSiftButton
+        items={items}
+        apiBaseUrl="https://api.sift.dev"
+        queryType={QueryTypes.CALCULATED_CHANNEL}
+      />
+    );
+
     expect(generateLinkFromQueryMock).not.toHaveBeenCalled();
 
     const menuButton = screen.getByRole('button', { name: 'Open in Sift' });

--- a/src/components/sharelink/OpenInSiftButton.tsx
+++ b/src/components/sharelink/OpenInSiftButton.tsx
@@ -4,7 +4,7 @@ import { AppEvents } from '@grafana/data';
 import { getAppEvents } from '@grafana/runtime';
 import { getFrontendHostnameDefaults } from './getFrontendHostnameDefaults';
 import { generateLinkFromQuery } from './generateLinkFromQuery';
-import type { SharelinkItems, SharelinkTimeRange } from '../../types';
+import { QueryTypes, type QueryType, type SharelinkItems, type SharelinkTimeRange } from '../../types';
 import { SquareShareIcon } from '../common/CustomIcons';
 
 interface SharelinkMenuItemProps {
@@ -13,34 +13,48 @@ interface SharelinkMenuItemProps {
   apiBaseUrl?: string;
   frontendUrl?: string;
   timeRange?: SharelinkTimeRange;
+  queryType?: QueryType;
 }
 
 function openLink(link: string) {
   window.open(link, '_blank', 'noopener,noreferrer');
 }
 
-async function copyToClipboard(value: string) {
-  try {
-    if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
-      throw new Error('Clipboard API not available');
-    }
-
-    await navigator.clipboard.writeText(value);
-    const appEvents = getAppEvents();
-    if (appEvents) {
-      appEvents.publish({
-        type: AppEvents.alertSuccess.name,
-        payload: ['Copied Sift share link to clipboard'],
-      });
-    }
-  } catch (err) {
-    console.error('Failed to copy link', err);
+function publishAlert(type: string, message: string) {
+  const appEvents = getAppEvents();
+  if (appEvents) {
+    appEvents.publish({
+      type,
+      payload: [message],
+    });
   }
 }
 
-export const OpenInSiftButton = ({ className, items, apiBaseUrl, frontendUrl, timeRange }: SharelinkMenuItemProps) => {
+async function copyToClipboard(value: string) {
+  if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
+    throw new Error('Clipboard API not available');
+  }
+
+  await navigator.clipboard.writeText(value);
+}
+
+export const OpenInSiftButton = ({
+  className,
+  items,
+  apiBaseUrl,
+  frontendUrl,
+  timeRange,
+  queryType,
+}: SharelinkMenuItemProps) => {
   const { shareLink, disabledReason } = useMemo(() => {
     const trimmedFrontendUrl = frontendUrl?.trim();
+
+    if (queryType === QueryTypes.CALCULATED_CHANNEL) {
+      return {
+        shareLink: null,
+        disabledReason: 'Open in Sift is unavailable when Query Mode is set to Calculated Channels',
+      };
+    }
 
     if (!apiBaseUrl && !trimmedFrontendUrl) {
       return {
@@ -49,7 +63,7 @@ export const OpenInSiftButton = ({ className, items, apiBaseUrl, frontendUrl, ti
       };
     }
 
-    if (!items || !items.channelIds || items.channelIds.length === 0) {
+    if (!items || items.channelIds.length === 0) {
       return {
         shareLink: null,
         disabledReason: 'Select a channel to enable share links',
@@ -63,7 +77,7 @@ export const OpenInSiftButton = ({ className, items, apiBaseUrl, frontendUrl, ti
         disabledReason: 'Configure the Sift API REST URL to enable share links',
       };
     }
-    
+
     try {
       return {
         shareLink: generateLinkFromQuery(hostname, items, timeRange),
@@ -76,7 +90,29 @@ export const OpenInSiftButton = ({ className, items, apiBaseUrl, frontendUrl, ti
         disabledReason: 'Failed to generate share link',
       };
     }
-  }, [apiBaseUrl, frontendUrl, items, timeRange]);
+  }, [apiBaseUrl, frontendUrl, items, queryType, timeRange]);
+
+  const handleOpen = () => {
+    if (!shareLink) {
+      return;
+    }
+
+    openLink(shareLink);
+  };
+
+  const handleCopy = async () => {
+    if (!shareLink) {
+      return;
+    }
+
+    try {
+      await copyToClipboard(shareLink);
+
+      publishAlert(AppEvents.alertSuccess.name, 'Copied Sift share link to clipboard');
+    } catch (err) {
+      console.error('Failed to copy link', err);
+    }
+  };
 
   return (
     <InlineLabel width="auto" transparent className={className} style={{ marginLeft: 'auto' }}>
@@ -87,18 +123,14 @@ export const OpenInSiftButton = ({ className, items, apiBaseUrl, frontendUrl, ti
               label="Open Link"
               disabled={!shareLink}
               onClick={() => {
-                if (shareLink) {
-                  openLink(shareLink);
-                }
+                handleOpen();
               }}
             />
             <Menu.Item
               label={shareLink ? 'Copy to Clipboard' : 'Copy (URL not set)'}
               disabled={!shareLink}
               onClick={() => {
-                if (shareLink) {
-                  void copyToClipboard(shareLink);
-                }
+                void handleCopy();
               }}
             />
           </Menu.Group>
@@ -108,7 +140,7 @@ export const OpenInSiftButton = ({ className, items, apiBaseUrl, frontendUrl, ti
           <Button
             onClick={(event) => {
               if (shareLink) {
-                openLink(shareLink);
+                handleOpen();
                 return;
               }
               openMenu(event);

--- a/src/components/sharelink/generateLinkFromQuery.test.ts
+++ b/src/components/sharelink/generateLinkFromQuery.test.ts
@@ -65,7 +65,7 @@ describe('generateLinkFromQuery', () => {
       expect(url.searchParams.get('panelType')).toBe('timeseries');
     });
 
-    it('should include assets in the query string', () => {
+    it('should include assets in the query string when runs are not present', () => {
       const items: SharelinkItems = {
         channelIds: ['channel-1'],
         assetIds: ['asset-1', 'asset-2'],
@@ -77,6 +77,21 @@ describe('generateLinkFromQuery', () => {
       const url = new URL(result);
       
       expect(url.searchParams.get('assetIds')).toBe('asset-1,asset-2');
+    });
+
+    it('should omit assets when runs are present', () => {
+      const items: SharelinkItems = {
+        channelIds: ['channel-1'],
+        assetIds: ['asset-1', 'asset-2'],
+        runIds: ['run-1', 'run-2'],
+        calculatedChannels: [],
+      };
+
+      const result = generateLinkFromQuery('app.siftstack.com', items);
+      const url = new URL(result);
+
+      expect(url.searchParams.has('assetIds')).toBe(false);
+      expect(url.searchParams.get('runIds')).toBe('run-1,run-2');
     });
 
     it('should include runs in the query string', () => {
@@ -224,8 +239,8 @@ describe('generateLinkFromQuery', () => {
       
       expect(url.searchParams.has('method')).toBe(true);
       expect(url.searchParams.has('channelIds')).toBe(true);
-      expect(url.searchParams.has('assetIds')).toBe(true);
       expect(url.searchParams.has('runIds')).toBe(true);
+      expect(url.searchParams.has('assetIds')).toBe(false);
     });
 
     it('should not double-encode URL components', () => {

--- a/src/components/sharelink/generateLinkFromQuery.test.ts
+++ b/src/components/sharelink/generateLinkFromQuery.test.ts
@@ -13,51 +13,59 @@ describe('generateLinkFromQuery', () => {
     it('should handle hostname without protocol and prepend https://', () => {
       const result = generateLinkFromQuery('app.siftstack.com', mockItems);
       
-      expect(result).toMatch(/^https:\/\/app\.siftstack\.com\/explorer#/);
+      expect(result).toMatch(/^https:\/\/app\.siftstack\.com\/explore\?/);
     });
 
     it('should handle hostname with https:// protocol', () => {
       const result = generateLinkFromQuery('https://app.siftstack.com', mockItems);
       
-      expect(result).toMatch(/^https:\/\/app\.siftstack\.com\/explorer#/);
+      expect(result).toMatch(/^https:\/\/app\.siftstack\.com\/explore\?/);
     });
 
     it('should handle hostname with http:// protocol', () => {
       const result = generateLinkFromQuery('http://localhost:3000', mockItems);
       
-      expect(result).toMatch(/^http:\/\/localhost:3000\/explorer#/);
+      expect(result).toMatch(/^http:\/\/localhost:3000\/explore\?/);
     });
 
     it('should handle hostname with port', () => {
       const result = generateLinkFromQuery('localhost:8080', mockItems);
       
-      expect(result).toMatch(/^https:\/\/localhost:8080\/explorer#/);
+      expect(result).toMatch(/^https:\/\/localhost:8080\/explore\?/);
     });
 
     it('should extract origin from full URL with path', () => {
       const result = generateLinkFromQuery('https://app.siftstack.com/some/path', mockItems);
       
       // Should use only the origin, not the path
-      expect(result).toMatch(/^https:\/\/app\.siftstack\.com\/explorer#/);
+      expect(result).toMatch(/^https:\/\/app\.siftstack\.com\/explore\?/);
       expect(result).not.toContain('/some/path');
     });
 
     it('should handle URL with query parameters by using only origin', () => {
       const result = generateLinkFromQuery('https://app.siftstack.com?foo=bar', mockItems);
       
-      expect(result).toMatch(/^https:\/\/app\.siftstack\.com\/explorer#/);
+      expect(result).toMatch(/^https:\/\/app\.siftstack\.com\/explore\?/);
       expect(result).not.toContain('?foo=bar');
     });
 
     it('should handle URL with trailing slash', () => {
       const result = generateLinkFromQuery('https://app.siftstack.com/', mockItems);
       
-      expect(result).toMatch(/^https:\/\/app\.siftstack\.com\/explorer#/);
+      expect(result).toMatch(/^https:\/\/app\.siftstack\.com\/explore\?/);
     });
   });
 
-  describe('hash parameters encoding', () => {
-    it('should include assets in hash', () => {
+  describe('dynamic URL parameters', () => {
+    it('should include the required method and panel type', () => {
+      const result = generateLinkFromQuery('app.siftstack.com', mockItems);
+      const url = new URL(result);
+
+      expect(url.searchParams.get('method')).toBe('single');
+      expect(url.searchParams.get('panelType')).toBe('timeseries');
+    });
+
+    it('should include assets in the query string', () => {
       const items: SharelinkItems = {
         channelIds: ['channel-1'],
         assetIds: ['asset-1', 'asset-2'],
@@ -66,11 +74,12 @@ describe('generateLinkFromQuery', () => {
       };
       
       const result = generateLinkFromQuery('app.siftstack.com', items);
+      const url = new URL(result);
       
-      expect(result).toContain('assets=asset-1%2Casset-2');
+      expect(url.searchParams.get('assetIds')).toBe('asset-1,asset-2');
     });
 
-    it('should include runs in hash', () => {
+    it('should include runs in the query string', () => {
       const items: SharelinkItems = {
         channelIds: ['channel-1'],
         assetIds: [],
@@ -79,78 +88,57 @@ describe('generateLinkFromQuery', () => {
       };
       
       const result = generateLinkFromQuery('app.siftstack.com', items);
+      const url = new URL(result);
       
-      expect(result).toContain('runs=run-1%2Crun-2');
+      expect(url.searchParams.get('runIds')).toBe('run-1,run-2');
     });
 
-    it('should base64 encode legend configuration', () => {
+    it('should include channels in the query string', () => {
       const result = generateLinkFromQuery('app.siftstack.com', mockItems);
+      const url = new URL(result);
       
-      // Should contain base64 encoded legend
-      expect(result).toContain('legend=');
-      // Base64 strings typically contain these characters
-      expect(result).toMatch(/legend=[A-Za-z0-9+/=%]+/);
+      expect(url.searchParams.get('channelIds')).toBe('channel-1,channel-2');
     });
 
-    it('should include time range in legend when provided', () => {
+    it('should include time range when provided', () => {
       const timeRange: SharelinkTimeRange = {
         from: '2024-01-01T00:00:00Z',
         to: '2024-01-02T00:00:00Z',
       };
       
       const result = generateLinkFromQuery('app.siftstack.com', mockItems, timeRange);
+      const url = new URL(result);
       
-      // The time range should be encoded in the legend parameter
-      expect(result).toContain('legend=');
+      expect(url.searchParams.get('startTime')).toBe(timeRange.from);
+      expect(url.searchParams.get('endTime')).toBe(timeRange.to);
     });
 
-    it('should handle calculated channels', () => {
+    it('should ignore calculated channels when building the URL', () => {
       const itemsWithCalc: SharelinkItems = {
         channelIds: ['channel-1'],
         assetIds: ['asset-1'],
         runIds: ['run-1'],
         calculatedChannels: [
           {
-            name: 'Calculated Channel',
-            sourceChannels: ['channel-1', 'channel-2'],
-            expression: '$1 + $2',
-            expressionDataType: 'DOUBLE',
+            name: 'calc-1',
+            sourceChannels: ['channel-1'],
+            expression: '$1',
+            expressionDataType: 'double',
           },
-        ],
-      };
-      
-      const result = generateLinkFromQuery('app.siftstack.com', itemsWithCalc);
-      
-      // Should still generate a valid URL with legend
-      expect(result).toMatch(/^https:\/\/app\.siftstack\.com\/explorer#/);
-      expect(result).toContain('legend=');
-    });
-
-    it('should handle multiple calculated channels', () => {
-      const itemsWithMultipleCalc: SharelinkItems = {
-        channelIds: ['channel-1'],
-        assetIds: ['asset-1'],
-        runIds: ['run-1'],
-        calculatedChannels: [
           {
-            name: 'Calc 1',
+            name: 'calc-2',
             sourceChannels: ['channel-1'],
             expression: '$1 * 2',
-            expressionDataType: 'DOUBLE',
-          },
-          {
-            name: 'Calc 2',
-            sourceChannels: ['channel-1', 'channel-2'],
-            expression: '$1 + $2',
-            expressionDataType: 'DOUBLE',
+            expressionDataType: 'double',
           },
         ],
       };
-      
-      const result = generateLinkFromQuery('app.siftstack.com', itemsWithMultipleCalc);
-      
-      expect(result).toMatch(/^https:\/\/app\.siftstack\.com\/explorer#/);
-      expect(result).toContain('legend=');
+
+      const result = generateLinkFromQuery('app.siftstack.com', itemsWithCalc);
+      const url = new URL(result);
+
+      expect(url.searchParams.get('channelIds')).toBe('channel-1');
+      expect(url.toString()).not.toContain('expression');
     });
   });
 
@@ -164,11 +152,11 @@ describe('generateLinkFromQuery', () => {
       };
       
       const result = generateLinkFromQuery('app.siftstack.com', items);
+      const url = new URL(result);
       
-      expect(result).toMatch(/^https:\/\/app\.siftstack\.com\/explorer#/);
-      // Should not include assets or runs parameters
-      expect(result).not.toContain('assets=');
-      expect(result).not.toContain('runs=');
+      expect(result).toMatch(/^https:\/\/app\.siftstack\.com\/explore\?/);
+      expect(url.searchParams.has('assetIds')).toBe(false);
+      expect(url.searchParams.has('runIds')).toBe(false);
     });
 
     it('should handle undefined asset and run arrays', () => {
@@ -180,10 +168,11 @@ describe('generateLinkFromQuery', () => {
       };
       
       const result = generateLinkFromQuery('app.siftstack.com', items);
+      const url = new URL(result);
       
-      expect(result).toMatch(/^https:\/\/app\.siftstack\.com\/explorer#/);
-      expect(result).not.toContain('assets=');
-      expect(result).not.toContain('runs=');
+      expect(result).toMatch(/^https:\/\/app\.siftstack\.com\/explore\?/);
+      expect(url.searchParams.has('assetIds')).toBe(false);
+      expect(url.searchParams.has('runIds')).toBe(false);
     });
 
     it('should handle special characters in channel IDs', () => {
@@ -195,23 +184,24 @@ describe('generateLinkFromQuery', () => {
       };
       
       const result = generateLinkFromQuery('app.siftstack.com', items);
+      const url = new URL(result);
       
-      expect(result).toMatch(/^https:\/\/app\.siftstack\.com\/explorer#/);
-      expect(result).toContain('legend=');
+      expect(result).toMatch(/^https:\/\/app\.siftstack\.com\/explore\?/);
+      expect(url.searchParams.get('channelIds')).toBe('channel-with-dash,channel_with_underscore');
     });
 
     it('should handle IPv4 addresses', () => {
       const result = generateLinkFromQuery('192.168.1.1:8080', mockItems);
       
-      expect(result).toMatch(/^https:\/\/192\.168\.1\.1:8080\/explorer#/);
+      expect(result).toMatch(/^https:\/\/192\.168\.1\.1:8080\/explore\?/);
     });
 
     it('should handle localhost variations', () => {
       const result1 = generateLinkFromQuery('localhost', mockItems);
-      expect(result1).toMatch(/^https:\/\/localhost\/explorer#/);
+      expect(result1).toMatch(/^https:\/\/localhost\/explore\?/);
 
       const result2 = generateLinkFromQuery('http://localhost:3000', mockItems);
-      expect(result2).toMatch(/^http:\/\/localhost:3000\/explorer#/);
+      expect(result2).toMatch(/^http:\/\/localhost:3000\/explore\?/);
     });
   });
 
@@ -224,20 +214,18 @@ describe('generateLinkFromQuery', () => {
       
       const url = new URL(result);
       expect(url.protocol).toMatch(/^https?:$/);
-      expect(url.pathname).toBe('/explorer');
-      expect(url.hash).toMatch(/^#.+/);
+      expect(url.pathname).toBe('/explore');
+      expect(url.search).toMatch(/^\?.+/);
     });
 
-    it('should properly encode hash parameters', () => {
+    it('should properly encode query parameters', () => {
       const result = generateLinkFromQuery('app.siftstack.com', mockItems);
       const url = new URL(result);
       
-      // Hash should be parseable as URLSearchParams (without the # prefix)
-      const hashParams = new URLSearchParams(url.hash.slice(1));
-      
-      expect(hashParams.has('legend')).toBe(true);
-      expect(hashParams.has('assets')).toBe(true);
-      expect(hashParams.has('runs')).toBe(true);
+      expect(url.searchParams.has('method')).toBe(true);
+      expect(url.searchParams.has('channelIds')).toBe(true);
+      expect(url.searchParams.has('assetIds')).toBe(true);
+      expect(url.searchParams.has('runIds')).toBe(true);
     });
 
     it('should not double-encode URL components', () => {

--- a/src/components/sharelink/generateLinkFromQuery.ts
+++ b/src/components/sharelink/generateLinkFromQuery.ts
@@ -30,11 +30,14 @@ export function generateLinkFromQuery(
   timeRange?: SharelinkTimeRange
 ): string {
   const url = new URL('/explore', normalizeFrontendOrigin(hostname));
+  const hasRuns = Boolean(items.runIds && items.runIds.length > 0);
 
   url.searchParams.set('method', 'single');
   url.searchParams.set('panelType', 'timeseries');
 
-  setCommaSeparatedParam(url.searchParams, 'assetIds', items.assetIds);
+  if (!hasRuns) {
+    setCommaSeparatedParam(url.searchParams, 'assetIds', items.assetIds);
+  }
   setCommaSeparatedParam(url.searchParams, 'runIds', items.runIds);
   setCommaSeparatedParam(url.searchParams, 'channelIds', items.channelIds);
 

--- a/src/components/sharelink/generateLinkFromQuery.ts
+++ b/src/components/sharelink/generateLinkFromQuery.ts
@@ -1,318 +1,50 @@
-/**
- * Utility for generating Explorer view links that the legacy explorer page
- * understands. This mirrors the URL encoding handled by
- * `explorePageUrlSync`.
- */
-import { SharelinkItems, SharelinkTimeRange } from '../../types';
+import type { SharelinkItems, SharelinkTimeRange } from '../../types';
 
-// Node typings are not guaranteed, so declare Buffer for TS.
-declare const Buffer: undefined | { from(data: string, encoding: string): { toString(encoding: string): string } };
-
-type DatazoomTuple = [number, number];
-
-export type CalculatedChannelConfig = {
-  channelKey: string;
-  name: string;
-  channelReferences: Record<string, string>;
-  expression: string;
-  dataType: string;
-  unitAbbreviatedName: string;
-};
-
-type LegendChannelConfigPayload = {
-  visible: boolean;
-  showTooltip: boolean;
-  channelId?: string;
-  calculatedChannelConfig?: CalculatedChannelConfig;
-};
-
-type LegendXAxisConfigPayload = {
-  fromDatetime: string;
-  toDatetime: string;
-  minDatetime: string;
-  maxDatetime: string;
-};
-
-type LegendConfigPayload = {
-  left: string[];
-  right: string[];
-  bottom: string[];
-  axes: Record<string, string[]>;
-  xAxes: Record<string, LegendXAxisConfigPayload>;
-  channels: Record<string, LegendChannelConfigPayload>;
-  stringChannelKeys?: string[];
-  axesRunLookup?: Record<string, string>;
-  axesDataZoom?: Record<string, DatazoomTuple>;
-  axesScaleType?: Record<string, 'linear' | 'log'>;
-};
-
-type OtherChartsPayload = Record<string, unknown>;
-
-type ExtraHashParams = Record<string, string>;
-
-type ExplorerLinkParams = {
-  /** Optional origin (e.g. https://example.com). If omitted, a relative URL is returned. */
-  origin?: string;
-  /** Path to the explorer route. Defaults to '/explorer'. */
-  basePath?: string;
-  /** Asset IDs to preload. */
-  assets?: string[];
-  /** Run IDs to preload. */
-  runs?: string[];
-  /** Full legend configuration that will be base64 encoded. */
-  legend?: LegendConfigPayload;
-  /** Serialized "other charts" payload (base64 encoded). */
-  otherCharts?: OtherChartsPayload;
-  /** Additional hash params to append verbatim. */
-  extraHashParams?: ExtraHashParams;
-};
-
-const BASE_PATH_DEFAULT = '/explorer';
-
-const HASH_KEYS = {
-  assets: 'assets',
-  runs: 'runs',
-  legend: 'legend',
-  otherCharts: 'otherCharts',
-} as const;
-
-type HashKey = keyof typeof HASH_KEYS;
-
-const JSON_BASE64_KEYS: HashKey[] = ['legend', 'otherCharts'];
-
-type JsonCapableKey = (typeof JSON_BASE64_KEYS)[number];
-
-type HashValueMap = Partial<Record<HashKey, unknown>>;
-
-function encodeURIComponentSafe(value: string): string {
-  if (typeof window !== 'undefined' && typeof window.encodeURIComponent === 'function') {
-    return window.encodeURIComponent(value);
-  }
-  // Fallback implementation if running under Node without DOM globals.
-  // encodeURIComponent is available globally in Node as well.
-  return encodeURIComponent(value);
-}
-
-function b64EncodeUnicode(str: string): string {
-  if (typeof window !== 'undefined' && typeof window.btoa === 'function') {
-    return window.btoa(
-      encodeURIComponentSafe(str).replace(/%([0-9A-F]{2})/g, (_, p1: string) => String.fromCharCode(parseInt(p1, 16)))
-    );
-  }
-
-  if (typeof Buffer !== 'undefined') {
-    return Buffer.from(str, 'utf8').toString('base64');
-  }
-
-  throw new Error('No base64 encoder available in this environment.');
-}
-
-function encodeJsonPayload(value: unknown): string {
-  return b64EncodeUnicode(JSON.stringify(value));
-}
-
-function normaliseBasePath(basePath: string): string {
-  if (!basePath.startsWith('/')) {
-    return `/${basePath}`;
-  }
-  // Remove trailing slash for consistency
-  return basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
-}
-
-function setIfPresent(hash: URLSearchParams, key: string, value: string | undefined | null) {
-  if (value !== undefined && value !== null && value !== '') {
-    hash.set(key, value);
-  }
-}
-
-function appendCommaSeparated(hash: URLSearchParams, key: string, values?: string[]) {
-  if (values && values.length > 0) {
-    hash.set(key, values.join(','));
-  }
-}
-
-function toHashValueMap(params: ExplorerLinkParams): HashValueMap {
-  return {
-    assets: params.assets,
-    runs: params.runs,
-    legend: params.legend,
-    otherCharts: params.otherCharts,
-  };
-}
-
-function setHashValue(hash: URLSearchParams, key: HashKey, value: unknown) {
-  if (value === undefined || value === null) {
-    return;
-  }
-
-  if (key === 'assets' || key === 'runs') {
-    appendCommaSeparated(hash, HASH_KEYS[key], value as string[]);
-    return;
-  }
-
-  if ((JSON_BASE64_KEYS as readonly string[]).includes(key)) {
-    const encoded = encodeJsonPayload(value);
-    setIfPresent(hash, HASH_KEYS[key], encoded);
-    return;
-  }
-
-  setIfPresent(hash, HASH_KEYS[key], String(value));
-}
-
-function createExplorerLink(params: ExplorerLinkParams): string {
-  const basePath = normaliseBasePath(params.basePath ?? BASE_PATH_DEFAULT);
-  const hashParams = new URLSearchParams();
-  const hashValueMap = toHashValueMap(params);
-
-  (Object.keys(hashValueMap) as HashKey[]).forEach((key) => {
-    setHashValue(hashParams, key, hashValueMap[key]);
-  });
-
-  if (params.extraHashParams) {
-    for (const [key, value] of Object.entries(params.extraHashParams)) {
-      if (value !== undefined && value !== null && value !== '') {
-        hashParams.set(key, value);
-      }
-    }
-  }
-
-  const hashString = hashParams.toString();
-
-  // If origin is provided, use URL constructor for proper URL building
-  if (params.origin) {
-    try {
-      const url = new URL(basePath, params.origin);
-      if (hashString) {
-        url.hash = hashString;
-      }
-      return url.toString();
-    } catch {
-      // If URL construction fails, fall back to string concatenation
-      // This shouldn't happen if origin is properly validated
-      const fullUrl = `${params.origin}${basePath}`;
-      return hashString ? `${fullUrl}#${hashString}` : fullUrl;
-    }
-  }
-
-  // Return relative URL
-  return hashString ? `${basePath}#${hashString}` : basePath;
-}
-
-export function generateLinkFromQuery(hostname: string, items: SharelinkItems, timeRange?: SharelinkTimeRange) {
-  // Guard against null/undefined hostname
+function normalizeFrontendOrigin(hostname: string): string {
   if (!hostname) {
     throw new Error('hostname is required');
   }
-  
-  // Normalize hostname to a valid origin URL
-  let origin: string;
+
   try {
-    // If hostname is already a valid URL, use it directly
-    const testUrl = new URL(hostname);
-    // Check if origin is valid (not null or 'null')
-    if (testUrl.origin && testUrl.origin !== 'null') {
-      origin = testUrl.origin;
-    } else {
-      // URL parsed but origin is invalid, treat as hostname
-      throw new Error('Invalid origin');
+    const parsedUrl = new URL(hostname);
+    if (parsedUrl.origin && parsedUrl.origin !== 'null') {
+      return parsedUrl.origin;
     }
+    throw new Error('Invalid origin');
   } catch {
-    // If not a valid URL, assume it's a hostname and prepend https://
     const withProtocol = `https://${hostname}`;
-    try {
-      const validatedUrl = new URL(withProtocol);
-      origin = validatedUrl.origin;
-    } catch {
-      // If still invalid, fall back to the string (shouldn't happen with valid hostnames)
-      origin = withProtocol;
-    }
+    const parsedUrl = new URL(withProtocol);
+    return parsedUrl.origin;
   }
-  const channelIds = items.channelIds;
-  const channelKeys = channelIds.map((_, index) => `channel-key-${index + 1}`);
-  const legendChannels: LegendConfigPayload['channels'] = {};
-  channelIds.forEach((channelId, index) => {
-    const channelKey = channelKeys[index];
-    legendChannels[channelKey] = {
-      channelId,
-      visible: true,
-      showTooltip: true,
-    };
-  });
-  if (items.calculatedChannels) {
-    items.calculatedChannels.forEach((calcChannel, index) => {
-      const channelKeyIndex = channelKeys.length + index;
-      const channelKeyName = `channel-key-${channelKeyIndex+1}`;
-      channelKeys.push(channelKeyName)
-
-      const channelReferences: Record<string, string> = {};
-      calcChannel.sourceChannels.forEach((el, index) => {
-        channelReferences[`$${index + 1}`] = el;
-      });
-
-      legendChannels[channelKeyName] = {
-        visible: true,
-        showTooltip: true,
-        calculatedChannelConfig: {
-          channelKey: channelKeyName,
-          name: calcChannel.name,
-          channelReferences: channelReferences,
-          expression: calcChannel.expression,
-          dataType: calcChannel.expressionDataType,
-          unitAbbreviatedName: '',
-        },
-      };
-    });
-  }
-
-  let xAxis = {
-    fromDatetime: '',
-    toDatetime: '',
-    minDatetime: '',
-    maxDatetime: '',
-  };
-  if (timeRange) {
-    xAxis.fromDatetime = timeRange.from;
-    xAxis.toDatetime = timeRange.to;
-  }
-
-  const legend: LegendConfigPayload = {
-    left: ['y-axis-1'],
-    right: [],
-    bottom: ['x-axis-1'],
-    axes: {
-      'y-axis-1': channelKeys,
-      'x-axis-1': channelKeys,
-    },
-    xAxes: {
-      'x-axis-1': xAxis,
-    },
-    channels: legendChannels,
-    stringChannelKeys: [],
-    axesRunLookup: {},
-    axesDataZoom: {
-      'y-axis-1': [0, 100],
-    },
-    axesScaleType: {
-      'y-axis-1': 'linear',
-    },
-  };
-
-  const assets = items.assetIds && items.assetIds.length > 0 ? items.assetIds : undefined;
-  const runs = items.runIds && items.runIds.length > 0 ? items.runIds : undefined;
-
-  return createExplorerLink({
-    origin,
-    assets,
-    runs,
-    legend
-  })
 }
 
-export type {
-  ExplorerLinkParams,
-  LegendConfigPayload,
-  LegendChannelConfigPayload,
-  LegendXAxisConfigPayload,
-  OtherChartsPayload,
-  ExtraHashParams,
-};
+function setCommaSeparatedParam(searchParams: URLSearchParams, key: string, values?: string[]) {
+  if (values && values.length > 0) {
+    searchParams.set(key, values.join(','));
+  }
+}
+
+export function generateLinkFromQuery(
+  hostname: string,
+  items: SharelinkItems,
+  timeRange?: SharelinkTimeRange
+): string {
+  const url = new URL('/explore', normalizeFrontendOrigin(hostname));
+
+  url.searchParams.set('method', 'single');
+  url.searchParams.set('panelType', 'timeseries');
+
+  setCommaSeparatedParam(url.searchParams, 'assetIds', items.assetIds);
+  setCommaSeparatedParam(url.searchParams, 'runIds', items.runIds);
+  setCommaSeparatedParam(url.searchParams, 'channelIds', items.channelIds);
+
+  if (timeRange?.from) {
+    url.searchParams.set('startTime', timeRange.from);
+  }
+
+  if (timeRange?.to) {
+    url.searchParams.set('endTime', timeRange.to);
+  }
+
+  return url.toString();
+}


### PR DESCRIPTION
# Pull Request

## Description

Updates the open in sift button to use the new e2 dynamic url format, restoring sharelink functionality to grafana. Note that calculated channels are no longer supported in sharelinks for the time being. 



## Type of change

Please check the boxes that apply to this pull request.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

Tested for:
- One channel
- multiple channels
- only asset specified
- asset and run specified
- refuses calculated channel query mode

## Checklist

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [x ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [x ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

https://github.com/user-attachments/assets/ea4a394c-8be5-4230-92f4-62cc35fd9ba7

