### PR TITLE
Feat: Add Combine by Channel Name

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -353,8 +353,11 @@ type bitFieldElementValues struct {
 }
 
 type frameKey struct {
-	// Either channelId or channelName
-	channelIdentifier   string
+	// channelId when combineAssets=false, channelName when combineAssets=true
+	channelIdentifier string
+	// dataType is used to differentiate channels in the event combineAssets=true
+	// and two or more channels share a name, but not a type
+	dataType            string
 	runId               string
 	bitFieldElementName string
 	isEnumString        bool
@@ -644,6 +647,7 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 		default:
 			key := frameKey{
 				channelIdentifier: channelIdentifier,
+				dataType:          d.Metadata.DataType,
 			}
 			if !combineRuns {
 				key.runId = d.Metadata.Run.RunId

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -62,6 +62,30 @@ var ValidSiftGrafanaDataTypes = []string{
 	// Note: No bytes
 }
 
+// Used to differentiate channels when the name is identical
+func dataTypeSuffix(dataType string) string {
+	switch dataType {
+	case "CHANNEL_DATA_TYPE_DOUBLE":
+		return "double"
+	case "CHANNEL_DATA_TYPE_FLOAT":
+		return "float"
+	case "CHANNEL_DATA_TYPE_INT_32":
+		return "int32"
+	case "CHANNEL_DATA_TYPE_INT_64":
+		return "int64"
+	case "CHANNEL_DATA_TYPE_UINT_32":
+		return "uint32"
+	case "CHANNEL_DATA_TYPE_UINT_64":
+		return "uint64"
+	case "CHANNEL_DATA_TYPE_BOOL":
+		return "bool"
+	case "CHANNEL_DATA_TYPE_STRING":
+		return "string"
+	default:
+		return dataType
+	}
+}
+
 const cacheTimeToLiveMax = time.Minute * 10
 const cacheTimeToLiveMin = cacheTimeToLiveMax / 2
 const cachePurgeTime = time.Minute * 5
@@ -250,7 +274,7 @@ type queryModel struct {
 	commonQueryProperties
 	ChannelDataQueries []channelDataQuery `json:"channelDataQueries"`
 	CombineRuns        bool               `json:"combineRuns"`
-	CombineAssets      bool               `json:"combineAssets"`
+	GroupByChannelName      bool               `json:"groupByChannelName"`
 	EnumDisplay        string             `json:"enumDisplay"`
 	QueryVersion       string             `json:"queryVersion"`
 	AnnotationType     string             `json:"annotationType"`
@@ -353,9 +377,9 @@ type bitFieldElementValues struct {
 }
 
 type frameKey struct {
-	// channelId when combineAssets=false, channelName when combineAssets=true
+	// channelId when groupByChannelName=false, channelName when groupByChannelName=true
 	channelIdentifier string
-	// dataType is used to differentiate channels in the event combineAssets=true
+	// dataType is used to differentiate channels in the event groupByChannelName=true
 	// and two or more channels share a name, but not a type
 	dataType            string
 	runId               string
@@ -430,9 +454,9 @@ func (d *SiftDatasource) query(ctx context.Context, pCtx backend.PluginContext, 
 	var frame *data.Frame
 	if fqm.AnnotationType != "" {
 		// Any annotationType set means we want the flat annotation frame format
-		frame, err = generateAnnotationFrame(responseData, calculatedChannelKeys, fqm.CombineRuns, fqm.CombineAssets, fqm.EnumDisplay)
+		frame, err = generateAnnotationFrame(responseData, calculatedChannelKeys, fqm.CombineRuns, fqm.GroupByChannelName, fqm.EnumDisplay)
 	} else {
-		frame, err = generateDataFrame(responseData, calculatedChannelKeys, fqm.CombineRuns, fqm.CombineAssets, fqm.EnumDisplay)
+		frame, err = generateDataFrame(responseData, calculatedChannelKeys, fqm.CombineRuns, fqm.GroupByChannelName, fqm.EnumDisplay)
 	}
 	if err != nil {
 		return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("error generating data frame: %v", err.Error()))
@@ -588,7 +612,7 @@ func runDataQueries(ctx context.Context, pCtx backend.PluginContext, queries []s
 	return allData, nil
 }
 
-func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys map[string]calculatedChannelKey, combineRuns bool, combineAssets bool, enumDisplay string) (*data.Frame, error) {
+func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys map[string]calculatedChannelKey, combineRuns bool, groupByChannelName bool, enumDisplay string) (*data.Frame, error) {
 	// create data frame response.
 	// For an overview on data frames and how grafana handles them:
 	// https://grafana.com/developers/plugin-tools/introduction/data-frames
@@ -598,7 +622,7 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 
 	for _, d := range responseData {
 		channelIdentifier := d.Metadata.Channel.ChannelId
-		if combineAssets {
+		if groupByChannelName {
 			channelIdentifier = d.Metadata.Channel.Name
 		}
 		switch d.Metadata.DataType {
@@ -845,12 +869,37 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 		return allDataKeys[i].runId < allDataKeys[j].runId && allDataKeys[i].channelIdentifier < allDataKeys[j].channelIdentifier
 	})
 
+	// When groupByChannelName=true, a channel name may appear with multiple data types
+	// This tracks those conflicts so we can later append the type on the displayed name
+	typeConflicts := map[string]bool{}
+	if groupByChannelName {
+		identifierTypes := map[string]map[string]bool{}
+		for _, k := range allDataKeys {
+			if k.dataType == "" {
+				continue
+			}
+			if identifierTypes[k.channelIdentifier] == nil {
+				identifierTypes[k.channelIdentifier] = map[string]bool{}
+			}
+			identifierTypes[k.channelIdentifier][k.dataType] = true
+		}
+		for ident, types := range identifierTypes {
+			if len(types) > 1 {
+				typeConflicts[ident] = true
+			}
+		}
+	}
+
 	// Track enum field base names for filtering later
 	enumFieldBaseNames := map[string]bool{}
 
 	for _, key := range allDataKeys {
 		m := md[key]
 		name := m.Channel.Name
+		// Append the channel type if there are type conflicts (pressure int32, pressure float)
+		if typeConflicts[key.channelIdentifier] {
+			name = fmt.Sprintf("%s %s", name, dataTypeSuffix(key.dataType))
+		}
 		include_channel_id := false
 		var field *data.Field
 		labels := data.Labels{}
@@ -869,10 +918,20 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 		if m.Run.RunId != "" && !combineRuns {
 			labels["run_id"] = m.Run.RunId
 		}
-		if m.Asset.Name != "" && !combineAssets {
+		groupedAcrossAssets := false
+		if groupByChannelName {
+			firstAssetId := dataMap[key][0].Metadata.Asset.AssetId
+			for _, d := range dataMap[key][1:] {
+				if d.Metadata.Asset.AssetId != firstAssetId {
+					groupedAcrossAssets = true
+					break
+				}
+			}
+		}
+		if m.Asset.Name != "" && !groupedAcrossAssets {
 			labels["asset"] = m.Asset.Name
 		}
-		if m.Asset.AssetId != "" && !combineAssets {
+		if m.Asset.AssetId != "" && !groupedAcrossAssets {
 			labels["asset_id"] = m.Asset.AssetId
 		}
 		if len(m.Channel.BitFieldElements) > 0 {
@@ -882,7 +941,7 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 				}
 			}
 		}
-		if include_channel_id && !combineAssets {
+		if include_channel_id && !groupedAcrossAssets {
 			labels["channel_id"] = m.Channel.ChannelId
 		}
 
@@ -1016,13 +1075,13 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 
 // generateAnnotationFrame creates an annotation-compatible data frame by reusing generateDataFrame
 // and converting it to a flat row-per-event format with metadata columns.
-func generateAnnotationFrame(responseData []queryResponseData, calculatedChannelKeys map[string]calculatedChannelKey, combineRuns bool, combineAssets bool, enumDisplay string) (*data.Frame, error) {
+func generateAnnotationFrame(responseData []queryResponseData, calculatedChannelKeys map[string]calculatedChannelKey, combineRuns bool, groupByChannelName bool, enumDisplay string) (*data.Frame, error) {
 	// Use combined mode for enums so we get a single "string (number)" field
 	annotationEnumDisplay := enumDisplay
 	if annotationEnumDisplay == "" || annotationEnumDisplay == EnumDisplayBoth {
 		annotationEnumDisplay = EnumDisplayCombined
 	}
-	sourceFrame, err := generateDataFrame(responseData, calculatedChannelKeys, combineRuns, combineAssets, annotationEnumDisplay)
+	sourceFrame, err := generateDataFrame(responseData, calculatedChannelKeys, combineRuns, groupByChannelName, annotationEnumDisplay)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -62,8 +62,8 @@ var ValidSiftGrafanaDataTypes = []string{
 	// Note: No bytes
 }
 
-// Used to differentiate channels when the name is identical
-func dataTypeSuffix(dataType string) string {
+// Provides a more concise data_type label
+func dataTypeLabel(dataType string) string {
 	switch dataType {
 	case "CHANNEL_DATA_TYPE_DOUBLE":
 		return "double"
@@ -81,6 +81,10 @@ func dataTypeSuffix(dataType string) string {
 		return "bool"
 	case "CHANNEL_DATA_TYPE_STRING":
 		return "string"
+	case "CHANNEL_DATA_TYPE_ENUM":
+		return "enum"
+	case "CHANNEL_DATA_TYPE_BIT_FIELD":
+		return "bitfield"
 	default:
 		return dataType
 	}
@@ -274,7 +278,7 @@ type queryModel struct {
 	commonQueryProperties
 	ChannelDataQueries []channelDataQuery `json:"channelDataQueries"`
 	CombineRuns        bool               `json:"combineRuns"`
-	GroupByChannelName      bool               `json:"groupByChannelName"`
+	GroupByChannelName bool               `json:"groupByChannelName"`
 	EnumDisplay        string             `json:"enumDisplay"`
 	QueryVersion       string             `json:"queryVersion"`
 	AnnotationType     string             `json:"annotationType"`
@@ -869,37 +873,12 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 		return allDataKeys[i].runId < allDataKeys[j].runId && allDataKeys[i].channelIdentifier < allDataKeys[j].channelIdentifier
 	})
 
-	// When groupByChannelName=true, a channel name may appear with multiple data types
-	// This tracks those conflicts so we can later append the type on the displayed name
-	typeConflicts := map[string]bool{}
-	if groupByChannelName {
-		identifierTypes := map[string]map[string]bool{}
-		for _, k := range allDataKeys {
-			if k.dataType == "" {
-				continue
-			}
-			if identifierTypes[k.channelIdentifier] == nil {
-				identifierTypes[k.channelIdentifier] = map[string]bool{}
-			}
-			identifierTypes[k.channelIdentifier][k.dataType] = true
-		}
-		for ident, types := range identifierTypes {
-			if len(types) > 1 {
-				typeConflicts[ident] = true
-			}
-		}
-	}
-
 	// Track enum field base names for filtering later
 	enumFieldBaseNames := map[string]bool{}
 
 	for _, key := range allDataKeys {
 		m := md[key]
 		name := m.Channel.Name
-		// Append the channel type if there are type conflicts (pressure int32, pressure float)
-		if typeConflicts[key.channelIdentifier] {
-			name = fmt.Sprintf("%s %s", name, dataTypeSuffix(key.dataType))
-		}
 		include_channel_id := false
 		var field *data.Field
 		labels := data.Labels{}
@@ -934,16 +913,14 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 		if m.Asset.AssetId != "" && !groupedAcrossAssets {
 			labels["asset_id"] = m.Asset.AssetId
 		}
-		if len(m.Channel.BitFieldElements) > 0 {
-			for _, bitFieldElement := range m.Channel.BitFieldElements {
-				if key.bitFieldElementName == bitFieldElement.Name {
-					labels["bitfield_element"] = bitFieldElement.Name
-				}
-			}
+		if key.bitFieldElementName != "" {
+			labels["bitfield_element"] = key.bitFieldElementName
 		}
 		if include_channel_id && !groupedAcrossAssets {
 			labels["channel_id"] = m.Channel.ChannelId
 		}
+
+		labels["data_type"] = dataTypeLabel(m.DataType)
 
 		switch m.DataType {
 		default:

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -878,7 +878,7 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 				}
 			}
 		}
-		if include_channel_id {
+		if include_channel_id && !combineAssets {
 			labels["channel_id"] = m.Channel.ChannelId
 		}
 

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -250,6 +250,7 @@ type queryModel struct {
 	commonQueryProperties
 	ChannelDataQueries []channelDataQuery `json:"channelDataQueries"`
 	CombineRuns        bool               `json:"combineRuns"`
+	CombineAssets      bool               `json:"combineAssets"`
 	EnumDisplay        string             `json:"enumDisplay"`
 	QueryVersion       string             `json:"queryVersion"`
 	AnnotationType     string             `json:"annotationType"`
@@ -352,7 +353,8 @@ type bitFieldElementValues struct {
 }
 
 type frameKey struct {
-	channelId           string
+	// Either channelId or channelName
+	channelIdentifier   string
 	runId               string
 	bitFieldElementName string
 	isEnumString        bool
@@ -425,9 +427,9 @@ func (d *SiftDatasource) query(ctx context.Context, pCtx backend.PluginContext, 
 	var frame *data.Frame
 	if fqm.AnnotationType != "" {
 		// Any annotationType set means we want the flat annotation frame format
-		frame, err = generateAnnotationFrame(responseData, calculatedChannelKeys, fqm.CombineRuns, fqm.EnumDisplay)
+		frame, err = generateAnnotationFrame(responseData, calculatedChannelKeys, fqm.CombineRuns, fqm.CombineAssets, fqm.EnumDisplay)
 	} else {
-		frame, err = generateDataFrame(responseData, calculatedChannelKeys, fqm.CombineRuns, fqm.EnumDisplay)
+		frame, err = generateDataFrame(responseData, calculatedChannelKeys, fqm.CombineRuns, fqm.CombineAssets, fqm.EnumDisplay)
 	}
 	if err != nil {
 		return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("error generating data frame: %v", err.Error()))
@@ -583,7 +585,7 @@ func runDataQueries(ctx context.Context, pCtx backend.PluginContext, queries []s
 	return allData, nil
 }
 
-func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys map[string]calculatedChannelKey, combineRuns bool, enumDisplay string) (*data.Frame, error) {
+func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys map[string]calculatedChannelKey, combineRuns bool, combineAssets bool, enumDisplay string) (*data.Frame, error) {
 	// create data frame response.
 	// For an overview on data frames and how grafana handles them:
 	// https://grafana.com/developers/plugin-tools/introduction/data-frames
@@ -592,11 +594,15 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 	allData := map[frameKey]map[int64]any{}
 
 	for _, d := range responseData {
+		channelIdentifier := d.Metadata.Channel.ChannelId
+		if combineAssets {
+			channelIdentifier = d.Metadata.Channel.Name
+		}
 		switch d.Metadata.DataType {
 		case "CHANNEL_DATA_TYPE_BIT_FIELD":
 			for _, bitFieldElement := range d.Metadata.Channel.BitFieldElements {
 				key := frameKey{
-					channelId:           d.Metadata.Channel.ChannelId,
+					channelIdentifier:   channelIdentifier,
 					bitFieldElementName: bitFieldElement.Name,
 				}
 				if !combineRuns {
@@ -610,8 +616,8 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 		case "CHANNEL_DATA_TYPE_ENUM":
 			if enumDisplay == EnumDisplayCombined {
 				key := frameKey{
-					channelId:      d.Metadata.Channel.ChannelId,
-					isEnumCombined: true,
+					channelIdentifier: channelIdentifier,
+					isEnumCombined:    true,
 				}
 				if !combineRuns {
 					key.runId = d.Metadata.Run.RunId
@@ -623,8 +629,8 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 			} else {
 				for _, v := range []bool{true, false} {
 					key := frameKey{
-						channelId:    d.Metadata.Channel.ChannelId,
-						isEnumString: v,
+						channelIdentifier: channelIdentifier,
+						isEnumString:      v,
 					}
 					if !combineRuns {
 						key.runId = d.Metadata.Run.RunId
@@ -637,7 +643,7 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 			}
 		default:
 			key := frameKey{
-				channelId: d.Metadata.Channel.ChannelId,
+				channelIdentifier: channelIdentifier,
 			}
 			if !combineRuns {
 				key.runId = d.Metadata.Run.RunId
@@ -832,7 +838,7 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 		allDataKeys = append(allDataKeys, k)
 	}
 	sort.SliceStable(allDataKeys, func(i, j int) bool {
-		return allDataKeys[i].runId < allDataKeys[j].runId && allDataKeys[i].channelId < allDataKeys[j].channelId
+		return allDataKeys[i].runId < allDataKeys[j].runId && allDataKeys[i].channelIdentifier < allDataKeys[j].channelIdentifier
 	})
 
 	// Track enum field base names for filtering later
@@ -859,10 +865,10 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 		if m.Run.RunId != "" && !combineRuns {
 			labels["run_id"] = m.Run.RunId
 		}
-		if m.Asset.Name != "" {
+		if m.Asset.Name != "" && !combineAssets {
 			labels["asset"] = m.Asset.Name
 		}
-		if m.Asset.AssetId != "" {
+		if m.Asset.AssetId != "" && !combineAssets {
 			labels["asset_id"] = m.Asset.AssetId
 		}
 		if len(m.Channel.BitFieldElements) > 0 {
@@ -1006,13 +1012,13 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 
 // generateAnnotationFrame creates an annotation-compatible data frame by reusing generateDataFrame
 // and converting it to a flat row-per-event format with metadata columns.
-func generateAnnotationFrame(responseData []queryResponseData, calculatedChannelKeys map[string]calculatedChannelKey, combineRuns bool, enumDisplay string) (*data.Frame, error) {
+func generateAnnotationFrame(responseData []queryResponseData, calculatedChannelKeys map[string]calculatedChannelKey, combineRuns bool, combineAssets bool, enumDisplay string) (*data.Frame, error) {
 	// Use combined mode for enums so we get a single "string (number)" field
 	annotationEnumDisplay := enumDisplay
 	if annotationEnumDisplay == "" || annotationEnumDisplay == EnumDisplayBoth {
 		annotationEnumDisplay = EnumDisplayCombined
 	}
-	sourceFrame, err := generateDataFrame(responseData, calculatedChannelKeys, combineRuns, annotationEnumDisplay)
+	sourceFrame, err := generateDataFrame(responseData, calculatedChannelKeys, combineRuns, combineAssets, annotationEnumDisplay)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -1247,6 +1247,110 @@ func (s *DatasourceTestSuite) TestGenerateDataFrameHandlesGroupByRun() {
 	s.Equal("run1", frame.Fields[1].Labels["run_id"])
 }
 
+func (s *DatasourceTestSuite) TestGenerateDataFrameGroupByChannelName_MergesSameNameChannels() {
+	t1 := time.Now()
+	t2 := t1.Add(time.Second)
+	responseData := []queryResponseData{
+		{
+			Metadata: queryResponseMetadata{
+				DataType: "CHANNEL_DATA_TYPE_DOUBLE",
+				Asset: struct {
+					AssetId string "json:\"assetId\""
+					Name    string "json:\"name\""
+				}{AssetId: "asset-rf", Name: "sat-1.rf"},
+				Channel: struct {
+					ChannelId        string                                "json:\"channelId\""
+					Name             string                                "json:\"name\""
+					EnumTypes        []queryResponseChannelEnumType        "json:\"enumTypes\""
+					BitFieldElements []queryResponseChannelBitFieldElement "json:\"bitFieldElements\""
+				}{ChannelId: "channel-id-1", Name: "Temperature"},
+			},
+			Values: json.RawMessage(`[{"timestamp": "` + t1.Format(time.RFC3339Nano) + `", "value": 25.0}]`),
+		},
+		{
+			Metadata: queryResponseMetadata{
+				DataType: "CHANNEL_DATA_TYPE_DOUBLE",
+				Asset: struct {
+					AssetId string "json:\"assetId\""
+					Name    string "json:\"name\""
+				}{AssetId: "asset-umb", Name: "sat-1.umb"},
+				Channel: struct {
+					ChannelId        string                                "json:\"channelId\""
+					Name             string                                "json:\"name\""
+					EnumTypes        []queryResponseChannelEnumType        "json:\"enumTypes\""
+					BitFieldElements []queryResponseChannelBitFieldElement "json:\"bitFieldElements\""
+				}{ChannelId: "channel-id-2", Name: "Temperature"},
+			},
+			Values: json.RawMessage(`[{"timestamp": "` + t2.Format(time.RFC3339Nano) + `", "value": 26.0}]`),
+		},
+	}
+
+	frame, err := generateDataFrame(responseData, nil, true, true, EnumDisplayBoth)
+	s.NoError(err)
+
+	// Both assets' Temperature channels should be merged into one series
+	s.Equal(2, len(frame.Fields))
+	s.Equal("time", frame.Fields[0].Name)
+	s.Equal("Temperature", frame.Fields[1].Name)
+
+	// Asset and channel_id labels should be absent when combining assets
+	s.Empty(frame.Fields[1].Labels["asset"])
+	s.Empty(frame.Fields[1].Labels["asset_id"])
+	s.Empty(frame.Fields[1].Labels["channel_id"])
+
+	// Values from both assets should be present
+	s.Equal(2, frame.Fields[1].Len())
+	s.Equal(25.0, *frame.Fields[1].At(0).(*float64))
+	s.Equal(26.0, *frame.Fields[1].At(1).(*float64))
+}
+
+func (s *DatasourceTestSuite) TestGenerateDataFrameGroupByChannelName_SeparatesConflictingTypes() {
+	now := time.Now()
+	responseData := []queryResponseData{
+		{
+			Metadata: queryResponseMetadata{
+				DataType: "CHANNEL_DATA_TYPE_DOUBLE",
+				Asset: struct {
+					AssetId string "json:\"assetId\""
+					Name    string "json:\"name\""
+				}{AssetId: "asset1", Name: "Asset 1"},
+				Channel: struct {
+					ChannelId        string                                "json:\"channelId\""
+					Name             string                                "json:\"name\""
+					EnumTypes        []queryResponseChannelEnumType        "json:\"enumTypes\""
+					BitFieldElements []queryResponseChannelBitFieldElement "json:\"bitFieldElements\""
+				}{ChannelId: "channel-1", Name: "Pressure"},
+			},
+			Values: json.RawMessage(`[{"timestamp": "` + now.Format(time.RFC3339Nano) + `", "value": 100.0}]`),
+		},
+		{
+			Metadata: queryResponseMetadata{
+				DataType: "CHANNEL_DATA_TYPE_INT_32",
+				Asset: struct {
+					AssetId string "json:\"assetId\""
+					Name    string "json:\"name\""
+				}{AssetId: "asset2", Name: "Asset 2"},
+				Channel: struct {
+					ChannelId        string                                "json:\"channelId\""
+					Name             string                                "json:\"name\""
+					EnumTypes        []queryResponseChannelEnumType        "json:\"enumTypes\""
+					BitFieldElements []queryResponseChannelBitFieldElement "json:\"bitFieldElements\""
+				}{ChannelId: "channel-2", Name: "Pressure"},
+			},
+			Values: json.RawMessage(`[{"timestamp": "` + now.Format(time.RFC3339Nano) + `", "value": 100}]`),
+		},
+	}
+
+	frame, err := generateDataFrame(responseData, nil, true, true, EnumDisplayBoth)
+	s.NoError(err)
+
+	// Channels with the same name but different data types must not be merged,
+	s.Equal(3, len(frame.Fields)) // time + two Pressure fields
+	s.Equal("time", frame.Fields[0].Name)
+	s.Equal("Pressure double", frame.Fields[1].Name)
+	s.Equal("Pressure int32", frame.Fields[2].Name)
+}
+
 func (s *DatasourceTestSuite) TestSplitQueriesIntoChunks() {
 	queries := []siftApiGetDataSubQuery{
 		{
@@ -2299,7 +2403,7 @@ func TestCheckInt64PrecisionLoss(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			frame := createTestFrame(tt.fieldType, tt.values, tt.labels)
-			
+
 			checkInt64PrecisionLoss(frame)
 
 			if tt.expectWarning {
@@ -2882,7 +2986,7 @@ func uint64Ptr(v uint64) *uint64 {
 
 func createTestFrame(fieldType string, values interface{}, labels map[string]string) *data.Frame {
 	frame := data.NewFrame("test_frame")
-	
+
 	var field *data.Field
 	switch fieldType {
 	case "int64":
@@ -2896,7 +3000,7 @@ func createTestFrame(fieldType string, values interface{}, labels map[string]str
 	default:
 		panic("unsupported field type")
 	}
-	
+
 	frame.Fields = append(frame.Fields, field)
 	return frame
 }

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -1344,11 +1344,14 @@ func (s *DatasourceTestSuite) TestGenerateDataFrameGroupByChannelName_SeparatesC
 	frame, err := generateDataFrame(responseData, nil, true, true, EnumDisplayBoth)
 	s.NoError(err)
 
-	// Channels with the same name but different data types must not be merged,
+	// Channels with the same name but different data types must not be merged
+	// they are distinguished by the data_type label
 	s.Equal(3, len(frame.Fields)) // time + two Pressure fields
 	s.Equal("time", frame.Fields[0].Name)
-	s.Equal("Pressure double", frame.Fields[1].Name)
-	s.Equal("Pressure int32", frame.Fields[2].Name)
+	s.Equal("Pressure", frame.Fields[1].Name)
+	s.Equal("Pressure", frame.Fields[2].Name)
+	s.Equal("double", frame.Fields[1].Labels["data_type"])
+	s.Equal("int32", frame.Fields[2].Labels["data_type"])
 }
 
 func (s *DatasourceTestSuite) TestSplitQueriesIntoChunks() {

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -1113,7 +1113,7 @@ func (s *DatasourceTestSuite) TestGenerateDataFrameWithMultipleDataTypes() {
 		},
 	}
 
-	frame, err := generateDataFrame(responseData, nil, false, EnumDisplayBoth)
+	frame, err := generateDataFrame(responseData, nil, false, false, EnumDisplayBoth)
 	s.NoError(err)
 
 	// Verify frame structure
@@ -1181,7 +1181,7 @@ func (s *DatasourceTestSuite) TestGenerateDataFrameHandlesCalculatedChannels() {
 		},
 	}
 
-	frame, err := generateDataFrame(responseData, calculatedChannelKeys, false, EnumDisplayBoth)
+	frame, err := generateDataFrame(responseData, calculatedChannelKeys, false, false, EnumDisplayBoth)
 	s.NoError(err)
 
 	// Verify frame structure
@@ -1234,7 +1234,7 @@ func (s *DatasourceTestSuite) TestGenerateDataFrameHandlesGroupByRun() {
 		},
 	}
 
-	frame, err := generateDataFrame(responseData, nil, false, EnumDisplayBoth)
+	frame, err := generateDataFrame(responseData, nil, false, false, EnumDisplayBoth)
 	s.NoError(err)
 
 	// Verify frame structure
@@ -1981,7 +1981,7 @@ func (s *DatasourceTestSuite) TestGenerateDataFrameWithEnumDisplayBoth() {
 		},
 	}
 
-	frame, err := generateDataFrame(responseData, nil, true, EnumDisplayBoth)
+	frame, err := generateDataFrame(responseData, nil, true, false, EnumDisplayBoth)
 	s.NoError(err)
 
 	// Verify frame structure - should have both _string and _value fields
@@ -2033,7 +2033,7 @@ func (s *DatasourceTestSuite) TestGenerateDataFrameWithEnumDisplayString() {
 		},
 	}
 
-	frame, err := generateDataFrame(responseData, nil, true, EnumDisplayString)
+	frame, err := generateDataFrame(responseData, nil, true, false, EnumDisplayString)
 	s.NoError(err)
 
 	// Verify frame structure - should only have string field without suffix
@@ -2080,7 +2080,7 @@ func (s *DatasourceTestSuite) TestGenerateDataFrameWithEnumDisplayValue() {
 		},
 	}
 
-	frame, err := generateDataFrame(responseData, nil, true, EnumDisplayValue)
+	frame, err := generateDataFrame(responseData, nil, true, false, EnumDisplayValue)
 	s.NoError(err)
 
 	// Verify frame structure - should only have value field without suffix
@@ -2150,7 +2150,7 @@ func (s *DatasourceTestSuite) TestGenerateDataFrameWithEnumDisplayMixedChannels(
 		},
 	}
 
-	frame, err := generateDataFrame(responseData, nil, true, EnumDisplayString)
+	frame, err := generateDataFrame(responseData, nil, true, false, EnumDisplayString)
 	s.NoError(err)
 
 	// Verify frame structure - enum should be filtered, non-enum should remain
@@ -2522,7 +2522,7 @@ func (s *DatasourceTestSuite) TestGenerateAnnotationFrameBasicDouble() {
 		},
 	}
 
-	frame, err := generateAnnotationFrame(responseData, nil, false, EnumDisplayBoth)
+	frame, err := generateAnnotationFrame(responseData, nil, false, false, EnumDisplayBoth)
 	s.NoError(err)
 	s.NotNil(frame)
 	s.Equal("annotations", frame.Name)
@@ -2610,7 +2610,7 @@ func (s *DatasourceTestSuite) TestGenerateAnnotationFrameMultipleChannelsSameTim
 		},
 	}
 
-	frame, err := generateAnnotationFrame(responseData, nil, false, EnumDisplayBoth)
+	frame, err := generateAnnotationFrame(responseData, nil, false, false, EnumDisplayBoth)
 	s.NoError(err)
 	s.NotNil(frame)
 
@@ -2664,7 +2664,7 @@ func (s *DatasourceTestSuite) TestGenerateAnnotationFrameEnumUsesCombinedMode() 
 	}
 
 	// When enumDisplay is "both", generateAnnotationFrame should override to combined
-	frame, err := generateAnnotationFrame(responseData, nil, false, EnumDisplayBoth)
+	frame, err := generateAnnotationFrame(responseData, nil, false, false, EnumDisplayBoth)
 	s.NoError(err)
 	s.NotNil(frame)
 
@@ -2700,7 +2700,7 @@ func (s *DatasourceTestSuite) TestGenerateAnnotationFrameNoMetadata() {
 		},
 	}
 
-	frame, err := generateAnnotationFrame(responseData, nil, false, "")
+	frame, err := generateAnnotationFrame(responseData, nil, false, false, "")
 	s.NoError(err)
 	s.NotNil(frame)
 
@@ -2734,7 +2734,7 @@ func (s *DatasourceTestSuite) TestGenerateAnnotationFrameHandlesNullValues() {
 		},
 	}
 
-	frame, err := generateAnnotationFrame(responseData, nil, false, "")
+	frame, err := generateAnnotationFrame(responseData, nil, false, false, "")
 	s.NoError(err)
 	s.NotNil(frame)
 
@@ -2768,7 +2768,7 @@ func (s *DatasourceTestSuite) TestGenerateAnnotationFrameBoolValues() {
 		},
 	}
 
-	frame, err := generateAnnotationFrame(responseData, nil, false, "")
+	frame, err := generateAnnotationFrame(responseData, nil, false, false, "")
 	s.NoError(err)
 	s.NotNil(frame)
 
@@ -2813,7 +2813,7 @@ func (s *DatasourceTestSuite) TestGenerateDataFrameEnumCombinedMode() {
 		},
 	}
 
-	frame, err := generateDataFrame(responseData, nil, false, EnumDisplayCombined)
+	frame, err := generateDataFrame(responseData, nil, false, false, EnumDisplayCombined)
 	s.NoError(err)
 
 	// Combined mode should produce a single field (plus time), not two
@@ -2861,12 +2861,12 @@ func (s *DatasourceTestSuite) TestGenerateDataFrameEnumCombinedVsBothMode() {
 	}
 
 	// "both" mode should produce two fields (string + value)
-	frameBoth, err := generateDataFrame(responseData, nil, false, EnumDisplayBoth)
+	frameBoth, err := generateDataFrame(responseData, nil, false, false, EnumDisplayBoth)
 	s.NoError(err)
 	s.Equal(3, len(frameBoth.Fields)) // time + Status_string + Status_value
 
 	// "combined" mode should produce one field
-	frameCombined, err := generateDataFrame(responseData, nil, false, EnumDisplayCombined)
+	frameCombined, err := generateDataFrame(responseData, nil, false, false, EnumDisplayCombined)
 	s.NoError(err)
 	s.Equal(2, len(frameCombined.Fields)) // time + Status
 }

--- a/src/components/VisualSiftQueryEditor.tsx
+++ b/src/components/VisualSiftQueryEditor.tsx
@@ -210,12 +210,12 @@ export const VisualSiftQueryEditor = (props: Props) => {
         </InlineLabel>
         <InlineLabel
           width="auto"
-          tooltip="Combine channels with the same name across multiple assets. Otherwise, each asset's channels will be separate series."
+          tooltip="Group channels that share the same name into a single series. Use this to combine assets with common channel names."
         >
           <Checkbox
-            label="Combine Assets"
-            checked={query.combineAssets ?? false}
-            onChange={(e) => onUpdateQuery({ ...query, combineAssets: e.currentTarget.checked })}
+            label="Group by Channel Name"
+            checked={query.groupByChannelName ?? false}
+            onChange={(e) => onUpdateQuery({ ...query, groupByChannelName: e.currentTarget.checked })}
           />
         </InlineLabel>
       </Section>

--- a/src/components/VisualSiftQueryEditor.tsx
+++ b/src/components/VisualSiftQueryEditor.tsx
@@ -210,7 +210,7 @@ export const VisualSiftQueryEditor = (props: Props) => {
         </InlineLabel>
         <InlineLabel
           width="auto"
-          tooltip="Group channels that share the same name into a single series. Use this to combine assets with common channel names."
+          tooltip="Group channels that share the same name and data type into a single series. Use this to combine assets with common channel names."
         >
           <Checkbox
             label="Group by Channel Name"

--- a/src/components/VisualSiftQueryEditor.tsx
+++ b/src/components/VisualSiftQueryEditor.tsx
@@ -208,6 +208,16 @@ export const VisualSiftQueryEditor = (props: Props) => {
             onChange={(e) => onUpdateQuery({ ...query, combineRuns: e.currentTarget.checked })}
           />
         </InlineLabel>
+        <InlineLabel
+          width="auto"
+          tooltip="Combine channels with the same name across multiple assets. Otherwise, each asset's channels will be separate series."
+        >
+          <Checkbox
+            label="Combine Assets"
+            checked={query.combineAssets ?? false}
+            onChange={(e) => onUpdateQuery({ ...query, combineAssets: e.currentTarget.checked })}
+          />
+        </InlineLabel>
       </Section>
       {/*TODO: aliasing <Section label="ALIAS"></Section >*/}
     </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,7 +69,7 @@ export type AnnotationQueryType = 'dataQuery' | 'annotationsQuery';
 export interface SiftQuery extends DataQuery {
   channelDataQueries?: ChannelDataQuery[];
   combineRuns?: boolean;
-  combineAssets?: boolean;
+  groupByChannelName?: boolean;
   enumDisplay?: EnumDisplayType;
   queryVersion: string;
   annotationType?: AnnotationQueryType;
@@ -79,7 +79,7 @@ export interface SiftQuery extends DataQuery {
 export const DEFAULT_QUERY: Partial<SiftQuery> = {
   channelDataQueries: [],
   combineRuns: true,
-  combineAssets: false,
+  groupByChannelName: false,
   enumDisplay: 'both',
   queryVersion: QUERY_VERSION,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,7 @@ export type AnnotationQueryType = 'dataQuery' | 'annotationsQuery';
 export interface SiftQuery extends DataQuery {
   channelDataQueries?: ChannelDataQuery[];
   combineRuns?: boolean;
+  combineAssets?: boolean;
   enumDisplay?: EnumDisplayType;
   queryVersion: string;
   annotationType?: AnnotationQueryType;
@@ -78,6 +79,7 @@ export interface SiftQuery extends DataQuery {
 export const DEFAULT_QUERY: Partial<SiftQuery> = {
   channelDataQueries: [],
   combineRuns: true,
+  combineAssets: false,
   enumDisplay: 'both',
   queryVersion: QUERY_VERSION,
 };


### PR DESCRIPTION
## Description

In Group By, adds a "Group by Channel Name" option which allows combining channels across assets, by keying channels by name, instead of id.

This was chosen over "Combine Assets" to be more explicit in the behavior, and make the behavior more clear in instances where you have multiple channels with the same name but different type on a single asset.

If channels share a name, but a different type, they remain separated, and the type is appended to the end of the name: "Pressure int32" and "Pressure int64" for example. This replaces the default grafana "Pressure 1" and "Pressure 2"

## Examples

**Multiple assets - channels with the same type**
<img width="3120" height="774" alt="image" src="https://github.com/user-attachments/assets/8414a959-e1aa-4af2-b6a7-28462c829e0f" />

**Multiple assets - channels with different types**

<img width="3120" height="613" alt="image" src="https://github.com/user-attachments/assets/0e8b362d-2868-4c4c-9464-675965536793" />

**New Combine by Channel Name option**
<img width="896" height="195" alt="image" src="https://github.com/user-attachments/assets/733423b3-c5d6-4cf6-b4d4-9cb46ae8f2fc" />

**Single Run, multiple assets, same channel name and type**
<img width="2813" height="1119" alt="image" src="https://github.com/user-attachments/assets/bdddcfeb-4c8d-4110-9678-45a039c69220" />
<img width="2813" height="1119" alt="image" src="https://github.com/user-attachments/assets/7f96119a-70a0-4b17-b513-21282049239c" />

**Enums and bitfields work correctly**
Data defined as the following
```
Asset A  →  state: {0: "off", 1: "on"}   flags: {bit0="off", bit1="on"}
Asset B  →  state: {0: "on",  1: "off"}  flags: {bit0="on",  bit1="off"}
```
<img width="3132" height="665" alt="image" src="https://github.com/user-attachments/assets/a3c28d49-9013-4ef3-9139-5ffe8c92767c" />

**Calculated Channels**
<img width="2793" height="1192" alt="image" src="https://github.com/user-attachments/assets/e8db30c5-61a0-4923-9a9c-a08332dbbdbf" />

<img width="2793" height="1192" alt="image" src="https://github.com/user-attachments/assets/2117dff4-794f-4287-808e-08fa3c37ce39" />
