### PR TITLE
fix: remove unused go package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "e2": "echo disabled. original command: playright test",
     "server": "docker-compose up --build",
     "server:watch": "docker-compose up -d --build && (docker-compose logs -f & ./dev-watch.sh)",
-    "sign": "npx --yes @grafana/sign-plugin@latest"
+    "sign": "npx --yes @grafana/sign-plugin@latest",
+    "postinstall": "rm -rf node_modules/flatted/golang"
   },
   "author": "Sift",
   "license": "Apache-2.0",


### PR DESCRIPTION
Removes a bundled go port of the flatted library now included since pinning flatted 3.4.2, which causes the grafana plugin validator to fail.
