### PR TITLE
Feat: Add async backend querying 

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       context: ./.config
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
-        grafana_version: ${GRAFANA_VERSION:-11.0.0}
+        grafana_version: ${GRAFANA_VERSION:-11.6.1}
     ports:
       - 3005:3000/tcp
     volumes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,11 @@
     "": {
       "name": "sift-grafana-datasource",
       "version": "1.4.4",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.10.6",
+        "@grafana/async-query-data": "^0.4.2",
         "@grafana/data": "^11.5.3",
         "@grafana/runtime": "^11.5.3",
         "@grafana/schema": "^11.5.3",
@@ -1151,6 +1153,22 @@
       }
     },
     "node_modules/@formatjs/intl-localematcher/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@grafana/async-query-data": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@grafana/async-query-data/-/async-query-data-0.4.3.tgz",
+      "integrity": "sha512-UK4deUpDbR6xZgVtLOS2Rg4O0heoA7AawXed8vX1xtGevbPkjvaqv7k/MD5VFMFhXb6dM325kkLlNO8EdLb3Jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "semver": "^7.6.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@grafana/async-query-data/node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sift-grafana-datasource",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sift-grafana-datasource",
-      "version": "1.4.4",
+      "version": "1.5.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8837,9 +8837,9 @@
       "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "dev": true,
       "funding": [
         {
@@ -9147,17 +9147,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -9692,9 +9692,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -18467,9 +18467,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sift-grafana-datasource",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "description": "",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
@@ -108,7 +108,9 @@
       "picomatch": "^4.0.4"
     },
     "serialize-javascript": "^7.0.3",
-    "form-data": "^4.0.4",
+    "form-data": "^4.0.6",
+    "fast-uri": "^3.1.3",
+    "ws": "^8.21.0",
     "qs": "^6.14.1",
     "tar": "^7.5.13",
     "@remix-run/router": "^1.23.2",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "dependencies": {
     "@emotion/css": "11.10.6",
+    "@grafana/async-query-data": "^0.4.2",
     "@grafana/data": "^11.5.3",
     "@grafana/runtime": "^11.5.3",
     "@grafana/schema": "^11.5.3",

--- a/pkg/plugin/async_query.go
+++ b/pkg/plugin/async_query.go
@@ -1,0 +1,324 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"golang.org/x/sync/semaphore"
+)
+
+const (
+	asyncJobStatusStarted  = "started"
+	asyncJobStatusRunning  = "running"
+	asyncJobStatusComplete = "complete"
+	asyncJobStatusError    = "error"
+
+	asyncJobTTL      = 10 * time.Minute
+	asyncJobReapTick = 1 * time.Minute
+
+	// defaultMaxConcurrentAsyncQueries bounds how many async queries (query blocks)
+	// execute against the Sift backend at once across every panel and dashboard served by
+	// this plugin instance. Without a bound, a dashboard with many panels would fan out
+	// unbounded concurrent reads into read-service, which has no admission control. The
+	// effective worst-case in-flight backend request count is this value times the
+	// per-target channel parallelism (maxParallelDataQueries). The default is set high
+	// enough not to reduce concurrency below the previous synchronous model for typical
+	// dashboards; tune it with the SIFT_ASYNC_MAX_CONCURRENT_QUERIES environment variable.
+	defaultMaxConcurrentAsyncQueries = 32
+	maxConcurrentAsyncQueriesEnvVar  = "SIFT_ASYNC_MAX_CONCURRENT_QUERIES"
+)
+
+// asyncMaxConcurrentQueries returns the configured async concurrency limit, falling
+// back to the default when the override is unset or invalid.
+func asyncMaxConcurrentQueries() int64 {
+	raw := os.Getenv(maxConcurrentAsyncQueriesEnvVar)
+	if raw == "" {
+		return defaultMaxConcurrentAsyncQueries
+	}
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || n < 1 {
+		log.DefaultLogger.Warn("invalid async concurrency override, using default",
+			"env", maxConcurrentAsyncQueriesEnvVar, "value", raw, "default", defaultMaxConcurrentAsyncQueries)
+		return defaultMaxConcurrentAsyncQueries
+	}
+	return n
+}
+
+// asyncJob represents an in-flight or completed async query.
+type asyncJob struct {
+	Status    string
+	Frames    []*data.Frame
+	Error     string
+	CreatedAt time.Time
+	cancel    context.CancelFunc
+}
+
+// asyncJobStore manages async query jobs with TTL-based cleanup and bounds the number
+// of concurrently executing backend queries via a weighted semaphore.
+type asyncJobStore struct {
+	mu   sync.RWMutex
+	jobs map[string]*asyncJob
+	done chan struct{}
+	sem  *semaphore.Weighted
+}
+
+func newAsyncJobStore(maxConcurrent int64) *asyncJobStore {
+	if maxConcurrent < 1 {
+		maxConcurrent = 1
+	}
+	s := &asyncJobStore{
+		jobs: make(map[string]*asyncJob),
+		done: make(chan struct{}),
+		sem:  semaphore.NewWeighted(maxConcurrent),
+	}
+	go s.reapLoop()
+	return s
+}
+
+func (s *asyncJobStore) reapLoop() {
+	ticker := time.NewTicker(asyncJobReapTick)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			s.mu.Lock()
+			now := time.Now()
+			for id, job := range s.jobs {
+				if now.Sub(job.CreatedAt) > asyncJobTTL {
+					if job.cancel != nil {
+						job.cancel()
+					}
+					delete(s.jobs, id)
+					log.DefaultLogger.Debug("async job reaped", "id", id)
+				}
+			}
+			s.mu.Unlock()
+		case <-s.done:
+			return
+		}
+	}
+}
+
+func (s *asyncJobStore) stop() {
+	close(s.done)
+}
+
+func (s *asyncJobStore) create(cancel context.CancelFunc) string {
+	id := uuid.New().String()
+	s.mu.Lock()
+	s.jobs[id] = &asyncJob{
+		Status:    asyncJobStatusStarted,
+		CreatedAt: time.Now(),
+		cancel:    cancel,
+	}
+	s.mu.Unlock()
+	return id
+}
+
+func (s *asyncJobStore) get(id string) (*asyncJob, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	job, ok := s.jobs[id]
+	return job, ok
+}
+
+func (s *asyncJobStore) complete(id string, frames []*data.Frame) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if job, ok := s.jobs[id]; ok {
+		job.Status = asyncJobStatusComplete
+		job.Frames = frames
+	}
+}
+
+func (s *asyncJobStore) fail(id string, errMsg string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if job, ok := s.jobs[id]; ok {
+		job.Status = asyncJobStatusError
+		job.Error = errMsg
+	}
+}
+
+func (s *asyncJobStore) cancel(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job, ok := s.jobs[id]
+	if !ok {
+		return false
+	}
+	if job.cancel != nil {
+		job.cancel()
+	}
+	delete(s.jobs, id)
+	return true
+}
+
+// poll returns a job's current status under a single lock. When the job has reached a
+// terminal state (complete or error) it is removed from the store so the result is
+// delivered exactly once and its frames are freed without waiting for the TTL reaper.
+func (s *asyncJobStore) poll(id string) (status string, frames []*data.Frame, errMsg string, ok bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job, exists := s.jobs[id]
+	if !exists {
+		return "", nil, "", false
+	}
+	status, frames, errMsg = job.Status, job.Frames, job.Error
+	if status == asyncJobStatusComplete || status == asyncJobStatusError {
+		delete(s.jobs, id)
+	}
+	return status, frames, errMsg, true
+}
+
+// asyncCustomMeta is the frame metadata format expected by @grafana/async-query-data.
+// The library checks for meta.custom.queryID and meta.custom.status on each frame.
+type asyncCustomMeta struct {
+	QueryID string `json:"queryID"`
+	Status  string `json:"status"`
+}
+
+// asyncStatusFrame builds an empty frame with the async status metadata that
+// DatasourceWithAsyncBackend's requestLooper inspects to decide whether to keep polling.
+func asyncStatusFrame(refID string, queryID string, status string) *data.Frame {
+	frame := data.NewFrame("async-status")
+	frame.RefID = refID
+	frame.Meta = &data.FrameMeta{
+		Custom: asyncCustomMeta{
+			QueryID: queryID,
+			Status:  status,
+		},
+	}
+	return frame
+}
+
+// handleAsyncQuery is called from QueryData. It inspects the query JSON for a
+// "queryID" field to determine whether this is an initial request or a poll.
+//
+// Initial request (no queryID): starts the query in a goroutine, returns a frame
+// with status "started".
+//
+// Poll request (has queryID): checks job status and returns:
+//   - status "running" frame if still in progress
+//   - the actual data frames if complete
+//   - an error response if the job failed or was not found
+func (d *SiftDatasource) handleAsyncQuery(pCtx backend.PluginContext, q backend.DataQuery, fqm queryModel) backend.DataResponse {
+	// Check if this query has a queryID (i.e. it's a poll request from the requestLooper)
+	var queryMeta struct {
+		QueryID string `json:"queryID"`
+	}
+	_ = json.Unmarshal(q.JSON, &queryMeta)
+
+	if queryMeta.QueryID != "" {
+		return d.pollAsyncQuery(q.RefID, queryMeta.QueryID)
+	}
+
+	return d.startAsyncQuery(pCtx, q, fqm)
+}
+
+// startAsyncQuery kicks off the query in a background goroutine and immediately
+// returns a frame with status "started" and the new queryID. The goroutine runs on
+// its own cancelable context (not the request context, which ends as soon as this
+// function returns), so cancellation and TTL reaping can abort the in-flight backend
+// read via the same context plumbing used by the synchronous path.
+func (d *SiftDatasource) startAsyncQuery(pCtx backend.PluginContext, q backend.DataQuery, fqm queryModel) backend.DataResponse {
+	jobCtx, jobCancel := context.WithCancel(context.Background())
+	queryID := d.asyncJobs.create(jobCancel)
+
+	log.DefaultLogger.Debug("async query started", "queryId", queryID, "refId", q.RefID)
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				d.asyncJobs.fail(queryID, fmt.Sprintf("panic: %v", r))
+				log.DefaultLogger.Error("async query panic", "queryId", queryID, "error", r)
+			}
+		}()
+
+		// Bound concurrent backend queries. Acquire blocks until a slot frees or the job
+		// is cancelled/reaped (jobCtx done), so queued jobs don't pile work onto
+		// read-service and a job cancelled while waiting never starts.
+		if err := d.asyncJobs.sem.Acquire(jobCtx, 1); err != nil {
+			d.asyncJobs.fail(queryID, "query cancelled")
+			return
+		}
+		defer d.asyncJobs.sem.Release(1)
+
+		res := d.query(jobCtx, pCtx, q, fqm)
+		if res.Error != nil {
+			d.asyncJobs.fail(queryID, res.Error.Error())
+			return
+		}
+
+		for _, frame := range res.Frames {
+			frame.RefID = q.RefID
+		}
+
+		d.asyncJobs.complete(queryID, res.Frames)
+		log.DefaultLogger.Debug("async query complete", "queryId", queryID, "frames", len(res.Frames))
+	}()
+
+	return backend.DataResponse{
+		Frames: data.Frames{asyncStatusFrame(q.RefID, queryID, asyncJobStatusStarted)},
+	}
+}
+
+// pollAsyncQuery checks the status of a running async job and returns the
+// appropriate response for the requestLooper.
+func (d *SiftDatasource) pollAsyncQuery(refID string, queryID string) backend.DataResponse {
+	status, frames, errMsg, ok := d.asyncJobs.poll(queryID)
+	if !ok {
+		return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("async query not found: %s", queryID))
+	}
+
+	switch status {
+	case asyncJobStatusComplete:
+		return backend.DataResponse{
+			Frames: frames,
+		}
+	case asyncJobStatusError:
+		return backend.ErrDataResponse(backend.StatusInternal, errMsg)
+	default:
+		// Still running — return a status frame so the requestLooper keeps polling
+		return backend.DataResponse{
+			Frames: data.Frames{asyncStatusFrame(refID, queryID, asyncJobStatusRunning)},
+		}
+	}
+}
+
+// callAsyncQueryCancel handles the "cancel" CallResource endpoint.
+// DatasourceWithAsyncBackend calls postResource('cancel', { queryId }) on unsubscribe.
+func (d *SiftDatasource) callAsyncQueryCancel(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+	var body struct {
+		QueryID string `json:"queryId"`
+	}
+	if err := json.Unmarshal(req.Body, &body); err != nil || body.QueryID == "" {
+		return sender.Send(&backend.CallResourceResponse{
+			Status: http.StatusBadRequest,
+			Body:   []byte(`{"error":"missing queryId"}`),
+		})
+	}
+
+	if d.asyncJobs.cancel(body.QueryID) {
+		log.DefaultLogger.Debug("async query cancelled", "queryId", body.QueryID)
+		return sender.Send(&backend.CallResourceResponse{
+			Status: http.StatusOK,
+			Body:   []byte(`{"status":"cancelled"}`),
+		})
+	}
+
+	return sender.Send(&backend.CallResourceResponse{
+		Status: http.StatusNotFound,
+		Body:   []byte(`{"error":"query not found"}`),
+	})
+}

--- a/pkg/plugin/async_query.go
+++ b/pkg/plugin/async_query.go
@@ -24,7 +24,16 @@ const (
 	asyncJobStatusError    = "error"
 
 	asyncJobTTL      = 10 * time.Minute
-	asyncJobReapTick = 1 * time.Minute
+	asyncJobReapTick = 10 * time.Second
+
+	// asyncJobIdleTimeout reclaims async jobs the frontend has stopped polling. A live
+	// query is polled at least every ~10s (the async-query-data max poll interval), so a
+	// job not polled within this window has been abandoned (panel superseded, time range
+	// changed, tab closed). Grafana does not reliably send a cancel in those cases (a known
+	// platform limitation), so this server-side reclamation — not the client cancel — is
+	// what frees the goroutine, the in-flight backend read, and the concurrency slot.
+	// callAsyncQueryCancel remains the best-effort fast path when the client does cancel.
+	asyncJobIdleTimeout = 30 * time.Second
 
 	// defaultMaxConcurrentAsyncQueries bounds how many async queries (query blocks)
 	// execute against the Sift backend at once across every panel and dashboard served by
@@ -56,11 +65,12 @@ func asyncMaxConcurrentQueries() int64 {
 
 // asyncJob represents an in-flight or completed async query.
 type asyncJob struct {
-	Status    string
-	Frames    []*data.Frame
-	Error     string
-	CreatedAt time.Time
-	cancel    context.CancelFunc
+	Status       string
+	Frames       []*data.Frame
+	Error        string
+	CreatedAt    time.Time
+	LastPolledAt time.Time
+	cancel       context.CancelFunc
 }
 
 // asyncJobStore manages async query jobs with TTL-based cleanup and bounds the number
@@ -91,21 +101,35 @@ func (s *asyncJobStore) reapLoop() {
 	for {
 		select {
 		case <-ticker.C:
-			s.mu.Lock()
-			now := time.Now()
-			for id, job := range s.jobs {
-				if now.Sub(job.CreatedAt) > asyncJobTTL {
-					if job.cancel != nil {
-						job.cancel()
-					}
-					delete(s.jobs, id)
-					log.DefaultLogger.Debug("async job reaped", "id", id)
-				}
-			}
-			s.mu.Unlock()
+			s.reapOnce(time.Now())
 		case <-s.done:
 			return
 		}
+	}
+}
+
+// reapOnce cancels and removes jobs abandoned by the frontend (not polled within
+// asyncJobIdleTimeout) or older than asyncJobTTL. Cancelling aborts the job's context,
+// which stops the in-flight backend read and releases its concurrency slot.
+func (s *asyncJobStore) reapOnce(now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, job := range s.jobs {
+		idle := now.Sub(job.LastPolledAt) > asyncJobIdleTimeout
+		expired := now.Sub(job.CreatedAt) > asyncJobTTL
+		if !idle && !expired {
+			continue
+		}
+		if job.cancel != nil {
+			job.cancel()
+		}
+		delete(s.jobs, id)
+		reason := "idle"
+		if expired {
+			reason = "ttl"
+		}
+		log.DefaultLogger.Info("async job reaped", "id", id, "reason", reason,
+			"status", job.Status, "idleMs", now.Sub(job.LastPolledAt).Milliseconds())
 	}
 }
 
@@ -115,11 +139,13 @@ func (s *asyncJobStore) stop() {
 
 func (s *asyncJobStore) create(cancel context.CancelFunc) string {
 	id := uuid.New().String()
+	now := time.Now()
 	s.mu.Lock()
 	s.jobs[id] = &asyncJob{
-		Status:    asyncJobStatusStarted,
-		CreatedAt: time.Now(),
-		cancel:    cancel,
+		Status:       asyncJobStatusStarted,
+		CreatedAt:    now,
+		LastPolledAt: now,
+		cancel:       cancel,
 	}
 	s.mu.Unlock()
 	return id
@@ -177,6 +203,10 @@ func (s *asyncJobStore) poll(id string) (status string, frames []*data.Frame, er
 	status, frames, errMsg = job.Status, job.Frames, job.Error
 	if status == asyncJobStatusComplete || status == asyncJobStatusError {
 		delete(s.jobs, id)
+	} else {
+		// Track liveness: the frontend polls a running job continually. When it stops
+		// (panel superseded / abandoned), reapOnce cancels the job by idle timeout.
+		job.LastPolledAt = time.Now()
 	}
 	return status, frames, errMsg, true
 }

--- a/pkg/plugin/async_query_test.go
+++ b/pkg/plugin/async_query_test.go
@@ -1,0 +1,664 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// asyncJobStore unit tests
+// ---------------------------------------------------------------------------
+
+func TestAsyncJobStore_CreateAndGet(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	_, cancel := context.WithCancel(context.Background())
+	id := store.create(cancel)
+
+	require.NotEmpty(t, id)
+
+	job, ok := store.get(id)
+	require.True(t, ok)
+	assert.Equal(t, asyncJobStatusStarted, job.Status)
+	assert.WithinDuration(t, time.Now(), job.CreatedAt, 2*time.Second)
+}
+
+func TestAsyncJobStore_GetNonExistent(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	_, ok := store.get("does-not-exist")
+	assert.False(t, ok)
+}
+
+func TestAsyncJobStore_Complete(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	_, cancel := context.WithCancel(context.Background())
+	id := store.create(cancel)
+
+	frames := []*data.Frame{data.NewFrame("test-frame")}
+	store.complete(id, frames)
+
+	job, ok := store.get(id)
+	require.True(t, ok)
+	assert.Equal(t, asyncJobStatusComplete, job.Status)
+	require.Len(t, job.Frames, 1)
+	assert.Equal(t, "test-frame", job.Frames[0].Name)
+}
+
+func TestAsyncJobStore_Fail(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	_, cancel := context.WithCancel(context.Background())
+	id := store.create(cancel)
+
+	store.fail(id, "something went wrong")
+
+	job, ok := store.get(id)
+	require.True(t, ok)
+	assert.Equal(t, asyncJobStatusError, job.Status)
+	assert.Equal(t, "something went wrong", job.Error)
+}
+
+func TestAsyncJobStore_Cancel(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	id := store.create(cancel)
+
+	// Cancel should return true and remove the job
+	ok := store.cancel(id)
+	assert.True(t, ok)
+
+	// Context should be cancelled
+	select {
+	case <-ctx.Done():
+		// expected
+	default:
+		t.Fatal("expected context to be cancelled")
+	}
+
+	// Job should be gone
+	_, found := store.get(id)
+	assert.False(t, found)
+}
+
+func TestAsyncJobStore_CancelNonExistent(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	ok := store.cancel("does-not-exist")
+	assert.False(t, ok)
+}
+
+func TestAsyncJobStore_CompleteNonExistent(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	// Should not panic
+	store.complete("does-not-exist", nil)
+	store.fail("does-not-exist", "error")
+}
+
+// ---------------------------------------------------------------------------
+// asyncStatusFrame tests
+// ---------------------------------------------------------------------------
+
+func TestAsyncStatusFrame(t *testing.T) {
+	frame := asyncStatusFrame("A", "query-123", "started")
+
+	assert.Equal(t, "async-status", frame.Name)
+	assert.Equal(t, "A", frame.RefID)
+	require.NotNil(t, frame.Meta)
+
+	custom, ok := frame.Meta.Custom.(asyncCustomMeta)
+	require.True(t, ok)
+	assert.Equal(t, "query-123", custom.QueryID)
+	assert.Equal(t, "started", custom.Status)
+}
+
+func TestAsyncStatusFrame_JSONSerialization(t *testing.T) {
+	frame := asyncStatusFrame("B", "q-456", "running")
+
+	customBytes, err := json.Marshal(frame.Meta.Custom)
+	require.NoError(t, err)
+
+	var parsed map[string]string
+	err = json.Unmarshal(customBytes, &parsed)
+	require.NoError(t, err)
+
+	assert.Equal(t, "q-456", parsed["queryID"])
+	assert.Equal(t, "running", parsed["status"])
+}
+
+// ---------------------------------------------------------------------------
+// pollAsyncQuery tests
+// ---------------------------------------------------------------------------
+
+func TestPollAsyncQuery_Running(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	ds := &SiftDatasource{asyncJobs: store}
+
+	_, cancel := context.WithCancel(context.Background())
+	id := store.create(cancel)
+
+	resp := ds.pollAsyncQuery("A", id)
+	require.Nil(t, resp.Error)
+	require.Len(t, resp.Frames, 1)
+
+	custom, ok := resp.Frames[0].Meta.Custom.(asyncCustomMeta)
+	require.True(t, ok)
+	assert.Equal(t, asyncJobStatusRunning, custom.Status)
+	assert.Equal(t, id, custom.QueryID)
+}
+
+func TestPollAsyncQuery_Complete(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	ds := &SiftDatasource{asyncJobs: store}
+
+	_, cancel := context.WithCancel(context.Background())
+	id := store.create(cancel)
+
+	resultFrame := data.NewFrame("result")
+	resultFrame.Fields = append(resultFrame.Fields, data.NewField("time", nil, []time.Time{time.Now()}))
+	store.complete(id, []*data.Frame{resultFrame})
+
+	resp := ds.pollAsyncQuery("A", id)
+	require.Nil(t, resp.Error)
+	require.Len(t, resp.Frames, 1)
+	assert.Equal(t, "result", resp.Frames[0].Name)
+}
+
+func TestPollAsyncQuery_Error(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	ds := &SiftDatasource{asyncJobs: store}
+
+	_, cancel := context.WithCancel(context.Background())
+	id := store.create(cancel)
+	store.fail(id, "query timeout")
+
+	resp := ds.pollAsyncQuery("A", id)
+	require.NotNil(t, resp.Error)
+	assert.Contains(t, resp.Error.Error(), "query timeout")
+}
+
+func TestPollAsyncQuery_NotFound(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	ds := &SiftDatasource{asyncJobs: store}
+
+	resp := ds.pollAsyncQuery("A", "nonexistent-id")
+	require.NotNil(t, resp.Error)
+	assert.Contains(t, resp.Error.Error(), "async query not found")
+}
+
+// ---------------------------------------------------------------------------
+// handleAsyncQuery routing tests
+// ---------------------------------------------------------------------------
+
+func TestHandleAsyncQuery_RoutesToPoll_WhenQueryIDPresent(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	ds := &SiftDatasource{asyncJobs: store}
+
+	_, cancel := context.WithCancel(context.Background())
+	id := store.create(cancel)
+	store.complete(id, []*data.Frame{data.NewFrame("done")})
+
+	queryJSON, _ := json.Marshal(map[string]interface{}{
+		"queryID":      id,
+		"queryVersion": "2.1",
+		"refId":        "A",
+	})
+
+	q := backend.DataQuery{
+		RefID: "A",
+		JSON:  queryJSON,
+	}
+
+	resp := ds.handleAsyncQuery(backend.PluginContext{}, q, queryModel{})
+	require.Nil(t, resp.Error)
+	require.Len(t, resp.Frames, 1)
+	assert.Equal(t, "done", resp.Frames[0].Name)
+}
+
+func TestHandleAsyncQuery_RoutesToStart_WhenNoQueryID(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	ds := &SiftDatasource{asyncJobs: store}
+
+	queryJSON, _ := json.Marshal(map[string]interface{}{
+		"queryVersion": "2.1",
+		"refId":        "A",
+	})
+
+	q := backend.DataQuery{
+		RefID: "A",
+		JSON:  queryJSON,
+	}
+
+	resp := ds.handleAsyncQuery(backend.PluginContext{}, q, queryModel{})
+
+	// Should return a "started" status frame
+	require.Nil(t, resp.Error)
+	require.Len(t, resp.Frames, 1)
+
+	custom, ok := resp.Frames[0].Meta.Custom.(asyncCustomMeta)
+	require.True(t, ok)
+	assert.Equal(t, asyncJobStatusStarted, custom.Status)
+	assert.NotEmpty(t, custom.QueryID)
+	assert.Equal(t, "A", resp.Frames[0].RefID)
+}
+
+// ---------------------------------------------------------------------------
+// callAsyncQueryCancel CallResource handler tests
+// ---------------------------------------------------------------------------
+
+func TestCallAsyncQueryCancel_Success(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	ds := &SiftDatasource{asyncJobs: store}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	id := store.create(cancel)
+
+	body, _ := json.Marshal(map[string]string{"queryId": id})
+	req := &backend.CallResourceRequest{
+		PluginContext: backend.PluginContext{},
+		Path:         "cancel",
+		Method:       http.MethodPost,
+		Body:         body,
+	}
+
+	sender := &mockCallResourceResponseSender{}
+	err := ds.callAsyncQueryCancel(context.Background(), req, sender)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, sender.status)
+	assert.Contains(t, string(sender.body), "cancelled")
+
+	// Context should be cancelled
+	select {
+	case <-ctx.Done():
+		// expected
+	default:
+		t.Fatal("expected context to be cancelled after cancel call")
+	}
+
+	// Job should no longer exist
+	_, found := store.get(id)
+	assert.False(t, found)
+}
+
+func TestCallAsyncQueryCancel_NotFound(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	ds := &SiftDatasource{asyncJobs: store}
+
+	body, _ := json.Marshal(map[string]string{"queryId": "nonexistent"})
+	req := &backend.CallResourceRequest{
+		PluginContext: backend.PluginContext{},
+		Path:         "cancel",
+		Method:       http.MethodPost,
+		Body:         body,
+	}
+
+	sender := &mockCallResourceResponseSender{}
+	err := ds.callAsyncQueryCancel(context.Background(), req, sender)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, sender.status)
+}
+
+func TestCallAsyncQueryCancel_MissingQueryId(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	ds := &SiftDatasource{asyncJobs: store}
+
+	req := &backend.CallResourceRequest{
+		PluginContext: backend.PluginContext{},
+		Path:         "cancel",
+		Method:       http.MethodPost,
+		Body:         []byte(`{}`),
+	}
+
+	sender := &mockCallResourceResponseSender{}
+	err := ds.callAsyncQueryCancel(context.Background(), req, sender)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, sender.status)
+}
+
+func TestCallAsyncQueryCancel_InvalidBody(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	ds := &SiftDatasource{asyncJobs: store}
+
+	req := &backend.CallResourceRequest{
+		PluginContext: backend.PluginContext{},
+		Path:         "cancel",
+		Method:       http.MethodPost,
+		Body:         []byte(`not json`),
+	}
+
+	sender := &mockCallResourceResponseSender{}
+	err := ds.callAsyncQueryCancel(context.Background(), req, sender)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, sender.status)
+}
+
+// ---------------------------------------------------------------------------
+// QueryData integration: async routing (all non-annotation queries are async)
+// ---------------------------------------------------------------------------
+
+func TestQueryData_StandardQuery_RoutesToAsync(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	ds := &SiftDatasource{asyncJobs: store}
+
+	// A standard data query (no annotationType) should go through async path
+	queryJSON, _ := json.Marshal(map[string]interface{}{
+		"queryVersion":       "2.1",
+		"refId":              "A",
+		"channelDataQueries": []interface{}{},
+	})
+
+	req := &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{},
+		Queries: []backend.DataQuery{
+			{
+				RefID: "A",
+				JSON:  queryJSON,
+				TimeRange: backend.TimeRange{
+					From: time.Now().Add(-1 * time.Hour),
+					To:   time.Now(),
+				},
+			},
+		},
+	}
+
+	resp, err := ds.QueryData(context.Background(), req)
+	require.NoError(t, err)
+
+	result, ok := resp.Responses["A"]
+	require.True(t, ok)
+	require.Nil(t, result.Error)
+	require.Len(t, result.Frames, 1)
+
+	// Verify the response is an async status frame with "started"
+	custom, ok := result.Frames[0].Meta.Custom.(asyncCustomMeta)
+	require.True(t, ok)
+	assert.Equal(t, asyncJobStatusStarted, custom.Status)
+	assert.NotEmpty(t, custom.QueryID)
+}
+
+func TestQueryData_PollReturnsComplete(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	ds := &SiftDatasource{asyncJobs: store}
+
+	// Pre-create a completed job
+	_, cancel := context.WithCancel(context.Background())
+	jobID := store.create(cancel)
+	resultFrame := data.NewFrame("my-result")
+	resultFrame.RefID = "A"
+	store.complete(jobID, []*data.Frame{resultFrame})
+
+	// Build a poll query with queryID set
+	queryJSON, _ := json.Marshal(map[string]interface{}{
+		"queryVersion":       "2.1",
+		"refId":              "A",
+		"queryID":            jobID,
+		"channelDataQueries": []interface{}{},
+	})
+
+	req := &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{},
+		Queries: []backend.DataQuery{
+			{
+				RefID: "A",
+				JSON:  queryJSON,
+				TimeRange: backend.TimeRange{
+					From: time.Now().Add(-1 * time.Hour),
+					To:   time.Now(),
+				},
+			},
+		},
+	}
+
+	resp, err := ds.QueryData(context.Background(), req)
+	require.NoError(t, err)
+
+	result, ok := resp.Responses["A"]
+	require.True(t, ok)
+	require.Nil(t, result.Error)
+	require.Len(t, result.Frames, 1)
+	assert.Equal(t, "my-result", result.Frames[0].Name)
+}
+
+func TestQueryData_AnnotationQuery_RunsSync(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	ds := &SiftDatasource{asyncJobs: store}
+
+	// An annotation query should NOT go through the async path
+	queryJSON, _ := json.Marshal(map[string]interface{}{
+		"queryVersion":       "2.1",
+		"refId":              "A",
+		"annotationType":     "annotationsQuery",
+		"channelDataQueries": []interface{}{},
+	})
+
+	req := &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{},
+		Queries: []backend.DataQuery{
+			{
+				RefID: "A",
+				JSON:  queryJSON,
+				TimeRange: backend.TimeRange{
+					From: time.Now().Add(-1 * time.Hour),
+					To:   time.Now(),
+				},
+			},
+		},
+	}
+
+	resp, err := ds.QueryData(context.Background(), req)
+	require.NoError(t, err)
+
+	result, ok := resp.Responses["A"]
+	require.True(t, ok)
+
+	// Annotation queries should not produce async-status frames
+	for _, frame := range result.Frames {
+		assert.NotEqual(t, "async-status", frame.Name, "annotation query should not produce async-status frames")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// concurrency limit configuration
+// ---------------------------------------------------------------------------
+
+func TestAsyncMaxConcurrentQueries(t *testing.T) {
+	t.Run("default when unset", func(t *testing.T) {
+		t.Setenv(maxConcurrentAsyncQueriesEnvVar, "")
+		assert.Equal(t, int64(defaultMaxConcurrentAsyncQueries), asyncMaxConcurrentQueries())
+	})
+	t.Run("valid override", func(t *testing.T) {
+		t.Setenv(maxConcurrentAsyncQueriesEnvVar, "16")
+		assert.Equal(t, int64(16), asyncMaxConcurrentQueries())
+	})
+	t.Run("non-numeric falls back to default", func(t *testing.T) {
+		t.Setenv(maxConcurrentAsyncQueriesEnvVar, "not-a-number")
+		assert.Equal(t, int64(defaultMaxConcurrentAsyncQueries), asyncMaxConcurrentQueries())
+	})
+	t.Run("non-positive falls back to default", func(t *testing.T) {
+		t.Setenv(maxConcurrentAsyncQueriesEnvVar, "0")
+		assert.Equal(t, int64(defaultMaxConcurrentAsyncQueries), asyncMaxConcurrentQueries())
+	})
+}
+
+func TestNewAsyncJobStore_ConcurrencyBound(t *testing.T) {
+	store := newAsyncJobStore(2)
+	defer store.stop()
+
+	require.True(t, store.sem.TryAcquire(2))
+	assert.False(t, store.sem.TryAcquire(1), "should be at the concurrency limit")
+	store.sem.Release(1)
+	assert.True(t, store.sem.TryAcquire(1), "permit should be reclaimable after release")
+}
+
+func TestNewAsyncJobStore_ClampsToMinimum(t *testing.T) {
+	// A non-positive limit is clamped to at least 1 so the store is always usable.
+	store := newAsyncJobStore(0)
+	defer store.stop()
+	assert.True(t, store.sem.TryAcquire(1))
+	assert.False(t, store.sem.TryAcquire(1))
+}
+
+// ---------------------------------------------------------------------------
+// poll removes terminal jobs (delivered once, freed without waiting for reaper)
+// ---------------------------------------------------------------------------
+
+func TestPoll_RemovesCompletedJob(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	_, cancel := context.WithCancel(context.Background())
+	id := store.create(cancel)
+	store.complete(id, []*data.Frame{data.NewFrame("done")})
+
+	status, frames, _, ok := store.poll(id)
+	require.True(t, ok)
+	assert.Equal(t, asyncJobStatusComplete, status)
+	require.Len(t, frames, 1)
+
+	// Gone after its terminal result is delivered.
+	_, found := store.get(id)
+	assert.False(t, found)
+	_, _, _, ok = store.poll(id)
+	assert.False(t, ok)
+}
+
+func TestPoll_RemovesErroredJob(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	_, cancel := context.WithCancel(context.Background())
+	id := store.create(cancel)
+	store.fail(id, "boom")
+
+	status, _, errMsg, ok := store.poll(id)
+	require.True(t, ok)
+	assert.Equal(t, asyncJobStatusError, status)
+	assert.Equal(t, "boom", errMsg)
+
+	_, found := store.get(id)
+	assert.False(t, found)
+}
+
+func TestPoll_KeepsRunningJob(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	_, cancel := context.WithCancel(context.Background())
+	id := store.create(cancel)
+
+	status, _, _, ok := store.poll(id)
+	require.True(t, ok)
+	assert.Equal(t, asyncJobStatusStarted, status)
+
+	// Still tracked so the client can keep polling.
+	_, found := store.get(id)
+	assert.True(t, found)
+}
+
+// ---------------------------------------------------------------------------
+// startAsyncQuery honors the concurrency bound and cancellation
+// ---------------------------------------------------------------------------
+
+func TestStartAsyncQuery_GatedByConcurrencyLimit(t *testing.T) {
+	store := newAsyncJobStore(1)
+	defer store.stop()
+	ds := &SiftDatasource{asyncJobs: store}
+
+	// Saturate the only slot so a new query must wait.
+	require.True(t, store.sem.TryAcquire(1))
+
+	q := backend.DataQuery{
+		RefID:     "A",
+		JSON:      []byte(`{"refId":"A"}`),
+		TimeRange: backend.TimeRange{From: time.Now().Add(-time.Hour), To: time.Now()},
+	}
+	resp := ds.startAsyncQuery(backend.PluginContext{}, q, queryModel{})
+	id := resp.Frames[0].Meta.Custom.(asyncCustomMeta).QueryID
+
+	// Slot held: the goroutine is blocked on Acquire and cannot reach a terminal state.
+	time.Sleep(50 * time.Millisecond)
+	status, _, _, ok := store.poll(id)
+	require.True(t, ok)
+	assert.Equal(t, asyncJobStatusStarted, status)
+
+	// Free the slot; the query now runs to a terminal state (empty query completes fast).
+	store.sem.Release(1)
+	assert.Eventually(t, func() bool {
+		status, _, _, ok := store.poll(id)
+		return !ok || status == asyncJobStatusComplete || status == asyncJobStatusError
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestStartAsyncQuery_CancelWhileQueued(t *testing.T) {
+	store := newAsyncJobStore(1)
+	defer store.stop()
+	ds := &SiftDatasource{asyncJobs: store}
+
+	// Saturate the slot so the new query queues on Acquire.
+	require.True(t, store.sem.TryAcquire(1))
+
+	q := backend.DataQuery{
+		RefID:     "A",
+		JSON:      []byte(`{"refId":"A"}`),
+		TimeRange: backend.TimeRange{From: time.Now().Add(-time.Hour), To: time.Now()},
+	}
+	resp := ds.startAsyncQuery(backend.PluginContext{}, q, queryModel{})
+	id := resp.Frames[0].Meta.Custom.(asyncCustomMeta).QueryID
+
+	// Cancel while queued: the goroutine's Acquire observes the cancelled context and exits
+	// without executing the backend query. The job is removed and the test completing proves
+	// there is no deadlock.
+	require.True(t, store.cancel(id))
+	assert.Eventually(t, func() bool {
+		_, ok := store.get(id)
+		return !ok
+	}, 2*time.Second, 10*time.Millisecond)
+}

--- a/pkg/plugin/async_query_test.go
+++ b/pkg/plugin/async_query_test.go
@@ -662,3 +662,78 @@ func TestStartAsyncQuery_CancelWhileQueued(t *testing.T) {
 		return !ok
 	}, 2*time.Second, 10*time.Millisecond)
 }
+
+// ---------------------------------------------------------------------------
+// idle / TTL reaping (server-side reclamation of abandoned jobs)
+// ---------------------------------------------------------------------------
+
+func TestReapOnce_ReapsIdleJob(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	id := store.create(cancel)
+	// Simulate the frontend having stopped polling well past the idle timeout.
+	store.jobs[id].LastPolledAt = time.Now().Add(-2 * asyncJobIdleTimeout)
+
+	store.reapOnce(time.Now())
+
+	_, ok := store.get(id)
+	assert.False(t, ok, "idle job should be reaped")
+	select {
+	case <-ctx.Done(): // expected: reap cancelled the job context
+	default:
+		t.Fatal("expected job context to be cancelled on idle reap")
+	}
+}
+
+func TestReapOnce_KeepsRecentlyPolledJob(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	_, cancel := context.WithCancel(context.Background())
+	id := store.create(cancel) // LastPolledAt = now
+
+	store.reapOnce(time.Now())
+
+	_, ok := store.get(id)
+	assert.True(t, ok, "recently-polled job should be kept")
+}
+
+func TestReapOnce_ReapsTtlExpired(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	id := store.create(cancel)
+	now := time.Now()
+	// Recently polled (not idle) but older than the TTL — the TTL backstop must still reap it.
+	store.jobs[id].CreatedAt = now.Add(-2 * asyncJobTTL)
+	store.jobs[id].LastPolledAt = now
+
+	store.reapOnce(now)
+
+	_, ok := store.get(id)
+	assert.False(t, ok, "TTL-expired job should be reaped even if recently polled")
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("expected job context to be cancelled on TTL reap")
+	}
+}
+
+func TestPoll_UpdatesLastPolledAt(t *testing.T) {
+	store := newAsyncJobStore(defaultMaxConcurrentAsyncQueries)
+	defer store.stop()
+
+	_, cancel := context.WithCancel(context.Background())
+	id := store.create(cancel)
+	// Backdate so the refresh is observable.
+	store.jobs[id].LastPolledAt = time.Now().Add(-asyncJobIdleTimeout)
+	before := store.jobs[id].LastPolledAt
+
+	status, _, _, ok := store.poll(id) // running -> refreshes LastPolledAt
+	require.True(t, ok)
+	assert.Equal(t, asyncJobStatusStarted, status)
+	assert.True(t, store.jobs[id].LastPolledAt.After(before), "poll should refresh LastPolledAt on a running job")
+}

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -141,6 +141,7 @@ func NewSiftDatasource(ctx context.Context, s backend.DataSourceInstanceSettings
 		channelsIdSearchCache:    channelIdsCache,
 		channelsNameSearchCache:  channelNameCache,
 		channelsRegexSearchCache: channelRegexCache,
+		asyncJobs:                newAsyncJobStore(asyncMaxConcurrentQueries()),
 	}, nil
 }
 
@@ -158,6 +159,9 @@ type SiftDatasource struct {
 	// channel caches use loader to avoid duplicate API calls at the same time
 	channelsNameSearchCache  *TypedCacheWithLoader[channelSearchKey, []Channel, string]
 	channelsRegexSearchCache *TypedCacheWithLoader[channelSearchKey, []Channel, string]
+
+	// asyncJobs tracks in-flight and completed async queries and bounds backend concurrency.
+	asyncJobs *asyncJobStore
 }
 
 // Dispose here tells plugin SDK that plugin wants to clean up resources when a new instance
@@ -165,6 +169,9 @@ type SiftDatasource struct {
 // be disposed and a new one will be created using NewSampleDatasource factory function.
 func (d *SiftDatasource) Dispose() {
 	// Clean up datasource instance resources.
+	if d.asyncJobs != nil {
+		d.asyncJobs.stop()
+	}
 }
 
 func (d *SiftDatasource) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
@@ -186,6 +193,9 @@ func (d *SiftDatasource) CallResource(ctx context.Context, req *backend.CallReso
 
 	case "resolve-query-to-sift-metadata":
 		return d.resolveQueryToSiftMetadata(ctx, req, sender)
+
+	case "cancel":
+		return d.callAsyncQueryCancel(ctx, req, sender)
 
 	default:
 		return sender.Send(&backend.CallResourceResponse{
@@ -215,7 +225,15 @@ func (d *SiftDatasource) QueryData(ctx context.Context, req *backend.QueryDataRe
 			continue
 		}
 
-		res := d.query(ctx, req.PluginContext, q, *fqm)
+		// Annotation queries run synchronously; all other data queries go through the
+		// async path so DatasourceWithAsyncBackend can poll for results and no single
+		// panel request is bound by Grafana's request timeout.
+		var res backend.DataResponse
+		if fqm.AnnotationType != "" {
+			res = d.query(ctx, req.PluginContext, q, *fqm)
+		} else {
+			res = d.handleAsyncQuery(req.PluginContext, q, *fqm)
+		}
 		// save the response in a hashmap
 		// based on with RefID as identifier
 		response.Responses[q.RefID] = res

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -198,6 +198,7 @@ func (d *SiftDatasource) CallResource(ctx context.Context, req *backend.CallReso
 		return d.callAsyncQueryCancel(ctx, req, sender)
 
 	default:
+		log.DefaultLogger.Warn("unhandled CallResource path", "path", req.Path, "method", req.Method)
 		return sender.Send(&backend.CallResourceResponse{
 			Status: http.StatusNotFound,
 		})

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -11,6 +11,15 @@ jest.mock('@grafana/runtime', () => ({
   },
 }));
 
+jest.mock('@grafana/async-query-data', () => ({
+  DatasourceWithAsyncBackend: class {
+    constructor() {}
+    postResource = jest.fn();
+    getResource = jest.fn();
+    getRef = jest.fn().mockReturnValue({ uid: 'test-uid', type: 'sift-datasource' });
+  },
+}));
+
 describe('SiftDataSource', () => {
   let datasource: SiftDataSource;
   let mockTemplateSrv: any;

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -6,7 +6,7 @@ import {
   DataSourceInstanceSettings,
   ScopedVars,
 } from '@grafana/data';
-import { DataSourceWithBackend } from '@grafana/runtime';
+import { DatasourceWithAsyncBackend } from '@grafana/async-query-data';
 import { Observable, from } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { SiftVariableSupport } from 'variables';
@@ -15,7 +15,7 @@ import { DEFAULT_QUERY, SiftDataSourceOptions, SiftQuery, QUERY_VERSION } from '
 import { ensureQueryDefaults, filterQueryBeforeRequest, replaceTemplateVariablesInQuery } from './utils';
 import { AnnotationQueryEditor } from './components/AnnotationQueryEditor';
 
-export class SiftDataSource extends DataSourceWithBackend<SiftQuery, SiftDataSourceOptions> {
+export class SiftDataSource extends DatasourceWithAsyncBackend<SiftQuery, SiftDataSourceOptions> {
   annotations: AnnotationSupport<SiftQuery> = {
     QueryEditor: AnnotationQueryEditor,
   };

--- a/src/datasourceCache.ts
+++ b/src/datasourceCache.ts
@@ -10,7 +10,7 @@ import {
   Labels,
   FieldConfig,
 } from '@grafana/data';
-import { Observable, firstValueFrom } from 'rxjs';
+import { Observable, lastValueFrom } from 'rxjs';
 import { SiftQuery } from './types';
 import { replaceTemplateVariablesInQuery } from './utils';
 
@@ -83,7 +83,7 @@ export class SiftDataSourceCache {
         newIntervalMs !== cacheEntry.fetchedIntervalMs || // new resolution/sample frequency requested
         liveLookbackTime <= newFrom // all data is liveish
       ) {
-        const fullData = await firstValueFrom(fetchCallback(request));
+        const fullData = await lastValueFrom(fetchCallback(request));
 
         // Store in cache
         this.cache.set(panelId, {
@@ -152,7 +152,7 @@ export class SiftDataSourceCache {
             },
           };
 
-          const subResp = await firstValueFrom(fetchCallback(subReq));
+          const subResp = await lastValueFrom(fetchCallback(subReq));
           if (!subResp.errors && subResp.data.length > 0) {
             newFrames.push(subResp.data);
           } else {
@@ -214,7 +214,7 @@ export class SiftDataSourceCache {
       return result;
     } catch (e) {
       console.error(`Panel ${panelId} - Failed to handle cache`, e);
-      return await firstValueFrom(fetchCallback(request));
+      return await lastValueFrom(fetchCallback(request));
     }
   }
 }

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -26,7 +26,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=11.0.0",
+    "grafanaDependency": ">=11.5.0",
     "plugins": []
   }
 }


### PR DESCRIPTION
# Pull Request

## Description

This PR completes the async backend querying work for the Sift Grafana datasource to fix panel-level
timeouts on long-range, multi-channel queries. Specifically, this PR builds on Alex Luck's draft (PR #50) and
carries it to a shippable state.

The problem being addressed in this PR is that the current datasource implementation runs a panel's query blocks (Grafana targets) sequentially. Panels that define one channel per query block and include multiple query blocks therefore load their channels back to back. If an example 7-day query per channel takes ~35s server-side, then a panel displaying two such channels defined in their own internal query blocks wold run in ~70s and exceed Grafana's 60s panel-request timeout (observed as a client-closed 499). The Sift web app renders the same set of channel queries without timing out because it loads channels independently and progressively.

The fix is to move the plugin implementation to Grafana's async query model (`@grafana/async-query-data`):
`QueryData` starts each data query in a background goroutine and returns immediately with a
"started" status frame; the frontend polls until the job completes. This removes the single
60s synchronous ceiling and lets a panel's query blocks run concurrently, so a panel renders
progressively and multi-block panels finish well under the timeout. 

**Changes on top of the original draft PR #50:**
- Bounded concurrency: Async queries run under a shared weighted semaphore
  so a full dashboard load cannot fan out unbounded concurrent reads into the Sift backend. The queued
  goroutine acquires a slot with the job's context, so it waits without piling work on the
  backend and a job cancelled while queued never starts.
- Cancellation propagation: The background goroutine runs on its own cancelable context (not the
  request context, which ends when the initial request returns). Cancellation and TTL reaping
  now abort the in-flight backend read through the existing query-path context plumbing, rather
  than only removing bookkeeping.
- Deterministic job cleanup: Terminal (complete/error) jobs are read and removed under a
  single lock in one `poll` call, so results are delivered once, freed promptly instead of
  waiting for the reaper, and read without a data race.

This implementation fix is motivated by the internal "High Volume Query Performance" project at Sift. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Automated (all passing locally):

- [x] `go test ./pkg/plugin/... -race` — existing async unit tests plus new coverage for the
  concurrency bound, env-var configuration, cancellation-while-queued, and delete-on-terminal poll.
- [x] `npm run test:ci` — 195 frontend tests pass.
- [x] `npm run lint` (0 errors) and `npm run lint:backend` (0 issues).
- [x] `go build ./...`, `go vet ./pkg/plugin/...`, and `npm run build` all succeed.

Manual (test evidence available internally):

- [x] Load the `System Power Metrics` panel over 7 days in a local Grafana with the built
  plugin and confirm it renders without the 60s timeout.
- [x] Confirm progressive rendering, cancellation aborts the backend read, and a full-dashboard
  load stays within the concurrency bound with read-service healthy.
- [x] Regression: single-query-block panels and annotation queries still behave correctly.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Screenshots of verification evidence could potentially include customer data, so they will be posted on the internal Linear ticket tracking progress on this PR implementation (ENG-12756).