### PR TITLE
fix: query enums at full fidelity

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -446,12 +446,27 @@ func (d *SiftDatasource) query(ctx context.Context, pCtx backend.PluginContext, 
 	}
 	afterLoadingQueries := time.Now()
 
-	responseData, err := runDataQueries(ctx, pCtx, queries, query, d)
+	// Running the standard query for enum channels can result in them being downsampled, and produce misleading
+	// results for the user. Instead, split them out for a separate full query.
+	enumQueries, otherQueries := splitQueriesByEnumDataType(d, queries)
+
+	responseData, err := runDataQueries(ctx, pCtx, otherQueries, query, query.Interval.Milliseconds(), d)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return backend.ErrDataResponse(backend.Status(499), "request cancelled") // 499 Client Closed Request
 		}
 		return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("error generating getting data: %v", err.Error()))
+	}
+
+	if len(enumQueries) > 0 {
+		enumResponseData, err := runDataQueries(ctx, pCtx, enumQueries, query, 0, d)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return backend.ErrDataResponse(backend.Status(499), "request cancelled") // 499 Client Closed Request
+			}
+			return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("error generating getting data: %v", err.Error()))
+		}
+		responseData = append(responseData, enumResponseData...)
 	}
 	afterExecutingQueries := time.Now()
 
@@ -574,6 +589,19 @@ func sortedKeys(set map[string]struct{}) []string {
 	return result
 }
 
+func splitQueriesByEnumDataType(d *SiftDatasource, queries []siftApiGetDataSubQuery) (enumQueries []siftApiGetDataSubQuery, otherQueries []siftApiGetDataSubQuery) {
+	for _, q := range queries {
+		if q.Channel != nil {
+			if channel, ok := d.channelsIdSearchCache.Get(q.Channel.ChannelId); ok && channel.DataType == "CHANNEL_DATA_TYPE_ENUM" {
+				enumQueries = append(enumQueries, q)
+				continue
+			}
+		}
+		otherQueries = append(otherQueries, q)
+	}
+	return enumQueries, otherQueries
+}
+
 func splitQueries(queries []siftApiGetDataSubQuery, chunkSize int) [][]siftApiGetDataSubQuery {
 	var chunks [][]siftApiGetDataSubQuery
 	for i := 0; i < len(queries); i += chunkSize {
@@ -586,7 +614,10 @@ func splitQueries(queries []siftApiGetDataSubQuery, chunkSize int) [][]siftApiGe
 	return chunks
 }
 
-func runDataQueries(ctx context.Context, pCtx backend.PluginContext, queries []siftApiGetDataSubQuery, query backend.DataQuery, d *SiftDatasource) ([]queryResponseData, error) {
+func runDataQueries(ctx context.Context, pCtx backend.PluginContext, queries []siftApiGetDataSubQuery, query backend.DataQuery, sampleMs int64, d *SiftDatasource) ([]queryResponseData, error) {
+	if len(queries) == 0 {
+		return nil, nil
+	}
 	chunks := splitQueries(queries, (len(queries)+maxParallelDataQueries-1)/maxParallelDataQueries)
 
 	var allData []queryResponseData
@@ -599,7 +630,7 @@ func runDataQueries(ctx context.Context, pCtx backend.PluginContext, queries []s
 	for _, chunk := range chunks {
 		chunk := chunk
 		g.Go(func() error {
-			dataResponse, err := d.getData(gCtx, pCtx, chunk, query)
+			dataResponse, err := d.getData(gCtx, pCtx, chunk, query, sampleMs)
 			if err != nil {
 				return err
 			}
@@ -1493,6 +1524,9 @@ func getChannelQueries(ctx context.Context, pCtx backend.PluginContext, cdq chan
 			}
 			for _, channels := range resultsExact {
 				for _, channel := range channels {
+					// Cache by channel ID so downstream lookups work
+					// regardless of whether a channel was resolved by ID, exact name, or regex.
+					d.channelsIdSearchCache.Set(channel.ChannelId, channel)
 					// Any channels that are not a compatible data type, remove from query
 					if _, ok := ValidSiftDataTypesMap[channel.DataType]; ok {
 						channelIds = append(channelIds, channel.ChannelId)
@@ -1505,6 +1539,7 @@ func getChannelQueries(ctx context.Context, pCtx backend.PluginContext, cdq chan
 			}
 			for _, channels := range resultsRegex {
 				for _, channel := range channels {
+					d.channelsIdSearchCache.Set(channel.ChannelId, channel)
 					// Any channels that are not a compatible data type, remove from query
 					if _, ok := ValidSiftDataTypesMap[channel.DataType]; ok {
 						channelIds = append(channelIds, channel.ChannelId)

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -1443,6 +1443,34 @@ func (s *DatasourceTestSuite) TestSplitQueriesHandlesChunkSizeOne() {
 	s.Equal("channel3", chunks[2][0].Channel.ChannelId)
 }
 
+// TestSplitQueriesByEnumDataType verifies that enum channels are routed to a separate
+// group so they can be requested at full fidelity, while numeric channels,
+// calculated channels, and channels with no cached schema fall back to the normal path.
+func (s *DatasourceTestSuite) TestSplitQueriesByEnumDataType() {
+	s.datasource.channelsIdSearchCache.Set("enum-channel-1", Channel{ChannelId: "enum-channel-1", DataType: "CHANNEL_DATA_TYPE_ENUM"})
+	s.datasource.channelsIdSearchCache.Set("enum-channel-2", Channel{ChannelId: "enum-channel-2", DataType: "CHANNEL_DATA_TYPE_ENUM"})
+	s.datasource.channelsIdSearchCache.Set("numeric-channel", Channel{ChannelId: "numeric-channel", DataType: "CHANNEL_DATA_TYPE_DOUBLE"})
+
+	queries := []siftApiGetDataSubQuery{
+		{Channel: &siftApiChannel{ChannelId: "enum-channel-1"}},
+		{Channel: &siftApiChannel{ChannelId: "numeric-channel"}},
+		{Channel: &siftApiChannel{ChannelId: "enum-channel-2"}},
+		{Channel: &siftApiChannel{ChannelId: "uncached-channel"}}, // no cache entry -> treated as non-enum
+		{CalculatedChannel: &siftApiCalculatedChannel{ChannelKey: "calc1"}},
+	}
+
+	enumQueries, otherQueries := splitQueriesByEnumDataType(s.datasource, queries)
+
+	s.Len(enumQueries, 2)
+	s.Equal("enum-channel-1", enumQueries[0].Channel.ChannelId)
+	s.Equal("enum-channel-2", enumQueries[1].Channel.ChannelId)
+
+	s.Len(otherQueries, 3)
+	s.Equal("numeric-channel", otherQueries[0].Channel.ChannelId)
+	s.Equal("uncached-channel", otherQueries[1].Channel.ChannelId)
+	s.Equal("calc1", otherQueries[2].CalculatedChannel.ChannelKey)
+}
+
 func (s *DatasourceTestSuite) TestGenerateQueries() {
 	runIds := []string{"run1", "run2"}
 	testCases := []struct {

--- a/pkg/plugin/sift_api_queries.go
+++ b/pkg/plugin/sift_api_queries.go
@@ -269,12 +269,12 @@ func (d *SiftDatasource) listSiftAnnotations(ctx context.Context, pCtx backend.P
 	return annotations, nil
 }
 
-func (d *SiftDatasource) getData(ctx context.Context, pCtx backend.PluginContext, subQueries []siftApiGetDataSubQuery, query backend.DataQuery) ([]queryResponseData, error) {
+func (d *SiftDatasource) getData(ctx context.Context, pCtx backend.PluginContext, subQueries []siftApiGetDataSubQuery, query backend.DataQuery, sampleMs int64) ([]queryResponseData, error) {
 	backendQuery := siftApiGetDataQuery{
 		Queries:   subQueries,
 		StartTime: query.TimeRange.From.Format(time.RFC3339Nano),
 		EndTime:   query.TimeRange.To.Format(time.RFC3339Nano),
-		SampleMs:  query.Interval.Milliseconds(),
+		SampleMs:  sampleMs,
 		PageSize:  10_000,
 	}
 


### PR DESCRIPTION
# Pull Request

## Description

Fixes an issue where enum channels are downsampled like any other numeric channel. Enum channels are now queried at full fidelity.

## Type of change

Please check the boxes that apply to this pull request.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

Testing was performed against a long lived asset generating enum data by querying 30 days of data. Before the fix, the data was clearly downsampled, with only three values seen at hour 17 as seen in the screenshot below.
With this PR, that same enum channel now provides full fidelity data.

**Before**
<img width="2989" height="987" alt="image" src="https://github.com/user-attachments/assets/0ade92cd-e17a-4611-bac8-aa2777d0e898" />

**After**
<img width="3025" height="993" alt="image" src="https://github.com/user-attachments/assets/990b6264-d3d1-4f3d-a010-14ee6d6553dc" />

Non-enum channels continue to be downsampled:
**30 days shows downsampling**
<img width="3012" height="914" alt="image" src="https://github.com/user-attachments/assets/207cabca-cf09-4c22-bea7-ab9b3e1cb032" />

**30 mins does not**
<img width="3007" height="909" alt="image" src="https://github.com/user-attachments/assets/70d3e691-548a-43b0-b6cb-557a9a162300" />

