### PR TITLE
feat: option to skip downsampling enum data

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -276,13 +276,14 @@ type channelDataQuery struct {
 
 type queryModel struct {
 	commonQueryProperties
-	ChannelDataQueries []channelDataQuery `json:"channelDataQueries"`
-	CombineRuns        bool               `json:"combineRuns"`
-	GroupByChannelName bool               `json:"groupByChannelName"`
-	EnumDisplay        string             `json:"enumDisplay"`
-	QueryVersion       string             `json:"queryVersion"`
-	AnnotationType     string             `json:"annotationType"`
-	AnnotationFilter   string             `json:"annotationFilter"`
+	ChannelDataQueries   []channelDataQuery `json:"channelDataQueries"`
+	CombineRuns          bool               `json:"combineRuns"`
+	GroupByChannelName   bool               `json:"groupByChannelName"`
+	EnumDisplay          string             `json:"enumDisplay"`
+	EnumSkipDownsampling bool               `json:"enumSkipDownsampling"`
+	QueryVersion         string             `json:"queryVersion"`
+	AnnotationType       string             `json:"annotationType"`
+	AnnotationFilter     string             `json:"annotationFilter"`
 }
 
 type queryResponse struct {
@@ -447,10 +448,15 @@ func (d *SiftDatasource) query(ctx context.Context, pCtx backend.PluginContext, 
 	afterLoadingQueries := time.Now()
 
 	// Running the standard query for enum channels can result in them being downsampled, and produce misleading
-	// results for the user. Instead, split them out for a separate full query.
-	enumQueries, otherQueries := splitQueriesByEnumDataType(d, queries)
+	// results for the user. Allow the option to perform enum queries with no downsampling.
+	var enumQueries, downsampledQueries []siftApiGetDataSubQuery
+	if fqm.EnumSkipDownsampling {
+		enumQueries, downsampledQueries = splitQueriesByEnumDataType(d, queries)
+	} else {
+		downsampledQueries = queries
+	}
 
-	responseData, err := runDataQueries(ctx, pCtx, otherQueries, query, query.Interval.Milliseconds(), d)
+	responseData, err := runDataQueries(ctx, pCtx, downsampledQueries, query, query.Interval.Milliseconds(), d)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return backend.ErrDataResponse(backend.Status(499), "request cancelled") // 499 Client Closed Request

--- a/src/components/VisualSiftQueryEditor.tsx
+++ b/src/components/VisualSiftQueryEditor.tsx
@@ -189,6 +189,16 @@ export const VisualSiftQueryEditor = (props: Props) => {
               width={20}
             />
           </InlineField>
+          <InlineLabel
+            width="auto"
+            tooltip="By default, enum channels are downsampled like other numeric channels. Enable this to always query enum data at full fidelity, at the cost of longer query times."
+          >
+            <Checkbox
+              label="Do not downsample enum data"
+              checked={query.enumSkipDownsampling ?? false}
+              onChange={(e) => onUpdateQuery({ ...query, enumSkipDownsampling: e.currentTarget.checked })}
+            />
+          </InlineLabel>
         </Section>
       )}
       <QueryEditor

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,7 @@ export interface SiftQuery extends DataQuery {
   combineRuns?: boolean;
   groupByChannelName?: boolean;
   enumDisplay?: EnumDisplayType;
+  enumSkipDownsampling?: boolean;
   queryVersion: string;
   annotationType?: AnnotationQueryType;
   annotationFilter?: string;
@@ -81,6 +82,7 @@ export const DEFAULT_QUERY: Partial<SiftQuery> = {
   combineRuns: true,
   groupByChannelName: false,
   enumDisplay: 'both',
+  enumSkipDownsampling: false,
   queryVersion: QUERY_VERSION,
 };
 


### PR DESCRIPTION
# Pull Request

## Description

#68 removed downsampling for enums, but may cause issues with existing workflows that need to query large periods of time. This PR adds the option to avoid downsampling enum data, defaulting to the previous behavior of downsampling enums.

## Type of change

Please check the boxes that apply to this pull request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested with local dev build.

<img width="929" height="262" alt="image" src="https://github.com/user-attachments/assets/a4cb8351-990a-4fe6-9a3d-b1c6b1631f21" />
