### PR TITLE
feat: Query downsampling options and fixes

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -280,7 +280,7 @@ type queryModel struct {
 	CombineRuns          bool               `json:"combineRuns"`
 	GroupByChannelName   bool               `json:"groupByChannelName"`
 	EnumDisplay          string             `json:"enumDisplay"`
-	EnumSkipDownsampling bool               `json:"enumSkipDownsampling"`
+	SkipDownsampling     bool               `json:"skipDownsampling"`
 	QueryVersion         string             `json:"queryVersion"`
 	AnnotationType       string             `json:"annotationType"`
 	AnnotationFilter     string             `json:"annotationFilter"`
@@ -447,32 +447,19 @@ func (d *SiftDatasource) query(ctx context.Context, pCtx backend.PluginContext, 
 	}
 	afterLoadingQueries := time.Now()
 
-	// Running the standard query for enum channels can result in them being downsampled, and produce misleading
-	// results for the user. Allow the option to perform enum queries with no downsampling.
-	var enumQueries, downsampledQueries []siftApiGetDataSubQuery
-	if fqm.EnumSkipDownsampling {
-		enumQueries, downsampledQueries = splitQueriesByEnumDataType(d, queries)
-	} else {
-		downsampledQueries = queries
+	// Running the standard query can result in data being downsampled, and produce misleading
+	// results for the user. Allow the option to query with no downsampling.
+	sampleMs := query.Interval.Milliseconds()
+	if fqm.SkipDownsampling {
+		sampleMs = 0
 	}
 
-	responseData, err := runDataQueries(ctx, pCtx, downsampledQueries, query, query.Interval.Milliseconds(), d)
+	responseData, err := runDataQueries(ctx, pCtx, queries, query, sampleMs, d)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return backend.ErrDataResponse(backend.Status(499), "request cancelled") // 499 Client Closed Request
 		}
 		return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("error generating getting data: %v", err.Error()))
-	}
-
-	if len(enumQueries) > 0 {
-		enumResponseData, err := runDataQueries(ctx, pCtx, enumQueries, query, 0, d)
-		if err != nil {
-			if errors.Is(err, context.Canceled) {
-				return backend.ErrDataResponse(backend.Status(499), "request cancelled") // 499 Client Closed Request
-			}
-			return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("error generating getting data: %v", err.Error()))
-		}
-		responseData = append(responseData, enumResponseData...)
 	}
 	afterExecutingQueries := time.Now()
 
@@ -593,19 +580,6 @@ func sortedKeys(set map[string]struct{}) []string {
 	}
 	slices.Sort(result)
 	return result
-}
-
-func splitQueriesByEnumDataType(d *SiftDatasource, queries []siftApiGetDataSubQuery) (enumQueries []siftApiGetDataSubQuery, otherQueries []siftApiGetDataSubQuery) {
-	for _, q := range queries {
-		if q.Channel != nil {
-			if channel, ok := d.channelsIdSearchCache.Get(q.Channel.ChannelId); ok && channel.DataType == "CHANNEL_DATA_TYPE_ENUM" {
-				enumQueries = append(enumQueries, q)
-				continue
-			}
-		}
-		otherQueries = append(otherQueries, q)
-	}
-	return enumQueries, otherQueries
 }
 
 func splitQueries(queries []siftApiGetDataSubQuery, chunkSize int) [][]siftApiGetDataSubQuery {
@@ -729,7 +703,7 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 				warnedChannels[channelIdentifier] = true
 				dataTypeWarnings = append(dataTypeWarnings, fmt.Sprintf(
 					"Channel %q returned inconsistent data types (%q vs %q)",
-					channelIdentifier, existing.DataType, d.Metadata.DataType, existing.DataType,
+					channelIdentifier, existing.DataType, d.Metadata.DataType,
 				))
 			}
 			dataMap[key] = append(dataMap[key], d)

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -276,14 +276,14 @@ type channelDataQuery struct {
 
 type queryModel struct {
 	commonQueryProperties
-	ChannelDataQueries   []channelDataQuery `json:"channelDataQueries"`
-	CombineRuns          bool               `json:"combineRuns"`
-	GroupByChannelName   bool               `json:"groupByChannelName"`
-	EnumDisplay          string             `json:"enumDisplay"`
-	SkipDownsampling     bool               `json:"skipDownsampling"`
-	QueryVersion         string             `json:"queryVersion"`
-	AnnotationType       string             `json:"annotationType"`
-	AnnotationFilter     string             `json:"annotationFilter"`
+	ChannelDataQueries []channelDataQuery `json:"channelDataQueries"`
+	CombineRuns        bool               `json:"combineRuns"`
+	GroupByChannelName bool               `json:"groupByChannelName"`
+	EnumDisplay        string             `json:"enumDisplay"`
+	SkipDownsampling   bool               `json:"skipDownsampling"`
+	QueryVersion       string             `json:"queryVersion"`
+	AnnotationType     string             `json:"annotationType"`
+	AnnotationFilter   string             `json:"annotationFilter"`
 }
 
 type queryResponse struct {
@@ -1526,8 +1526,10 @@ func getChannelQueries(ctx context.Context, pCtx backend.PluginContext, cdq chan
 			if err != nil {
 				return nil, fmt.Errorf("error looking up exact channels: %w", err)
 			}
-			for _, channels := range resultsExact {
-				for _, channel := range channels {
+
+			// Iterate by `channelNameExactSearches` to ensure we return results in a deterministic order
+			for _, key := range channelNameExactSearches {
+				for _, channel := range resultsExact[key] {
 					// Cache by channel ID so downstream lookups work
 					// regardless of whether a channel was resolved by ID, exact name, or regex.
 					d.channelsIdSearchCache.Set(channel.ChannelId, channel)
@@ -1541,8 +1543,10 @@ func getChannelQueries(ctx context.Context, pCtx backend.PluginContext, cdq chan
 			if err != nil {
 				return nil, fmt.Errorf("error looking up regex channels: %w", err)
 			}
-			for _, channels := range resultsRegex {
-				for _, channel := range channels {
+
+			// Iterate by `channelNameRegexSearches` to ensure we return results in a deterministic order
+			for _, key := range channelNameRegexSearches {
+				for _, channel := range resultsRegex[key] {
 					d.channelsIdSearchCache.Set(channel.ChannelId, channel)
 					// Any channels that are not a compatible data type, remove from query
 					if _, ok := ValidSiftDataTypesMap[channel.DataType]; ok {

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -660,6 +660,8 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 	dataMap := map[frameKey][]queryResponseData{}
 	md := map[frameKey]queryResponseMetadata{}
 	allData := map[frameKey]map[int64]any{}
+	dataTypeWarnings := []string{}
+	warnedChannels := map[string]bool{}
 
 	for _, d := range responseData {
 		channelIdentifier := d.Metadata.Channel.ChannelId
@@ -712,10 +714,23 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 		default:
 			key := frameKey{
 				channelIdentifier: channelIdentifier,
-				dataType:          d.Metadata.DataType,
+			}
+			// Only key off of DataType if grouping by channel name to keep behavior consistent with versions before grouping
+			// by channel name was added.
+			if groupByChannelName {
+				key.dataType = d.Metadata.DataType
 			}
 			if !combineRuns {
 				key.runId = d.Metadata.Run.RunId
+			}
+			// Inconsistent dataTypes, while not keyed by default, shouldn't occur and should be logged and reported to users
+			// due to the potential for it resulting in invalid data.
+			if existing, ok := md[key]; ok && existing.DataType != d.Metadata.DataType && !warnedChannels[channelIdentifier] {
+				warnedChannels[channelIdentifier] = true
+				dataTypeWarnings = append(dataTypeWarnings, fmt.Sprintf(
+					"Channel %q returned inconsistent data types (%q vs %q)",
+					channelIdentifier, existing.DataType, d.Metadata.DataType, existing.DataType,
+				))
 			}
 			dataMap[key] = append(dataMap[key], d)
 			if _, ok := md[key]; !ok {
@@ -1079,6 +1094,15 @@ func generateDataFrame(responseData []queryResponseData, calculatedChannelKeys m
 		Type:        data.FrameTypeTimeSeriesWide,
 		TypeVersion: data.FrameTypeVersion{0, 1},
 		Notices:     []data.Notice{},
+	}
+
+	// Log and warn for detected while grouping channels above.
+	for _, warning := range dataTypeWarnings {
+		frame.Meta.Notices = append(frame.Meta.Notices, data.Notice{
+			Severity: data.NoticeSeverityWarning,
+			Text:     warning,
+		})
+		log.DefaultLogger.Warn(warning)
 	}
 
 	// Check for precision loss in INT64/UINT64 fields

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -2987,6 +2987,33 @@ func uint64Ptr(v uint64) *uint64 {
 	return &v
 }
 
+func (s *DatasourceTestSuite) TestGetChannelQueriesOrderIsDeterministic() {
+	cdq := channelDataQuery{
+		ChannelQueries: []channelQuery{
+			{ChannelName: "Channel", NameAsRegex: true},
+		},
+	}
+	assetIds := []string{"asset1", "asset2", "asset3"}
+
+	// asset1 then asset2 then asset3, in the order the API returns them within each asset.
+	// "Bytes Channel" is on asset2 but is dropped by the data type filter.
+	expected := []string{"channel1", "channel2", "channel3", "channel4", "channel6"}
+
+	// Test multiple times to more likely catch non-deterministic behavior
+	for i := 0; i < 10; i++ {
+		s.datasource.channelsRegexSearchCache.Flush()
+
+		queries, err := getChannelQueries(context.Background(), s.pCtx, cdq, nil, assetIds, s.datasource)
+		require.NoError(s.T(), err)
+
+		returned := make([]string, 0, len(queries))
+		for _, q := range queries {
+			returned = append(returned, q.Channel.ChannelId)
+		}
+		require.Equalf(s.T(), expected, returned, "order not deterministic: expected %v returned %v", expected, returned)
+	}
+}
+
 func createTestFrame(fieldType string, values interface{}, labels map[string]string) *data.Frame {
 	frame := data.NewFrame("test_frame")
 

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -1443,34 +1443,6 @@ func (s *DatasourceTestSuite) TestSplitQueriesHandlesChunkSizeOne() {
 	s.Equal("channel3", chunks[2][0].Channel.ChannelId)
 }
 
-// TestSplitQueriesByEnumDataType verifies that enum channels are routed to a separate
-// group so they can be requested at full fidelity, while numeric channels,
-// calculated channels, and channels with no cached schema fall back to the normal path.
-func (s *DatasourceTestSuite) TestSplitQueriesByEnumDataType() {
-	s.datasource.channelsIdSearchCache.Set("enum-channel-1", Channel{ChannelId: "enum-channel-1", DataType: "CHANNEL_DATA_TYPE_ENUM"})
-	s.datasource.channelsIdSearchCache.Set("enum-channel-2", Channel{ChannelId: "enum-channel-2", DataType: "CHANNEL_DATA_TYPE_ENUM"})
-	s.datasource.channelsIdSearchCache.Set("numeric-channel", Channel{ChannelId: "numeric-channel", DataType: "CHANNEL_DATA_TYPE_DOUBLE"})
-
-	queries := []siftApiGetDataSubQuery{
-		{Channel: &siftApiChannel{ChannelId: "enum-channel-1"}},
-		{Channel: &siftApiChannel{ChannelId: "numeric-channel"}},
-		{Channel: &siftApiChannel{ChannelId: "enum-channel-2"}},
-		{Channel: &siftApiChannel{ChannelId: "uncached-channel"}}, // no cache entry -> treated as non-enum
-		{CalculatedChannel: &siftApiCalculatedChannel{ChannelKey: "calc1"}},
-	}
-
-	enumQueries, otherQueries := splitQueriesByEnumDataType(s.datasource, queries)
-
-	s.Len(enumQueries, 2)
-	s.Equal("enum-channel-1", enumQueries[0].Channel.ChannelId)
-	s.Equal("enum-channel-2", enumQueries[1].Channel.ChannelId)
-
-	s.Len(otherQueries, 3)
-	s.Equal("numeric-channel", otherQueries[0].Channel.ChannelId)
-	s.Equal("uncached-channel", otherQueries[1].Channel.ChannelId)
-	s.Equal("calc1", otherQueries[2].CalculatedChannel.ChannelKey)
-}
-
 func (s *DatasourceTestSuite) TestGenerateQueries() {
 	runIds := []string{"run1", "run2"}
 	testCases := []struct {

--- a/src/components/VisualSiftQueryEditor.tsx
+++ b/src/components/VisualSiftQueryEditor.tsx
@@ -191,12 +191,12 @@ export const VisualSiftQueryEditor = (props: Props) => {
           </InlineField>
           <InlineLabel
             width="auto"
-            tooltip="By default, enum channels are downsampled like other numeric channels. Enable this to always query enum data at full fidelity, at the cost of longer query times."
+            tooltip="Enable to always query data from Sift at full fidelity, at the cost of longer query times."
           >
             <Checkbox
-              label="Do not downsample enum data"
-              checked={query.enumSkipDownsampling ?? false}
-              onChange={(e) => onUpdateQuery({ ...query, enumSkipDownsampling: e.currentTarget.checked })}
+              label="Disable Downsampling"
+              checked={query.skipDownsampling ?? false}
+              onChange={(e) => onUpdateQuery({ ...query, skipDownsampling: e.currentTarget.checked })}
             />
           </InlineLabel>
         </Section>

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,7 +71,7 @@ export interface SiftQuery extends DataQuery {
   combineRuns?: boolean;
   groupByChannelName?: boolean;
   enumDisplay?: EnumDisplayType;
-  enumSkipDownsampling?: boolean;
+  skipDownsampling?: boolean;
   queryVersion: string;
   annotationType?: AnnotationQueryType;
   annotationFilter?: string;
@@ -82,7 +82,7 @@ export const DEFAULT_QUERY: Partial<SiftQuery> = {
   combineRuns: true,
   groupByChannelName: false,
   enumDisplay: 'both',
-  enumSkipDownsampling: false,
+  skipDownsampling: false,
   queryVersion: QUERY_VERSION,
 };
 


### PR DESCRIPTION
# Pull Request

## Description

Adds the option to disable downsampling for any query. A previous PR added this ability to enums. That option will be removed in favor of a universal option for disabling downsampling.

Fixes:
- Removes dataType as a default label. This was added in a recent PR for grouping by channel name, and will now only be included as a label when that option is selected, matching previous behavior. Since inconsistent dataTypes should be unexpected behavior, a user facing warning will appear if queried data comes back with inconsistent dataType labels. 
- Queried data is now returned in a deterministic order.

## How Has This Been Tested?

Additional unit testing.
Dev testing of the plugin to verify new downsampling option behaves as intended.

<img width="914" height="244" alt="image" src="https://github.com/user-attachments/assets/0cab4a83-85f3-47ab-b5f8-8424d304594a" />

